### PR TITLE
docs: add architecture vision documentation (ADR-0001 and RFC-0002)

### DIFF
--- a/docs/adr/adr-0001-dual-layer-context-architecture.md
+++ b/docs/adr/adr-0001-dual-layer-context-architecture.md
@@ -1,0 +1,252 @@
+# ADR-0001: Dual-Layer Context Architecture
+
+**Status**: ACCEPTED
+**Date**: 2025-12-19
+**Author**: holistic-orchestrator (adapted from hestai-core ADR-0007)
+**Implements**: HestAI-MCP foundational architecture
+
+---
+
+## Context
+
+### The Problem
+
+Traditional AI agent workflows lose context between sessions. When working on complex projects:
+- Context is lost between conversations
+- Agents can't access project history or decisions
+- Multiple agents create conflicting files
+- System governance rules drift across projects
+- Symlinks and worktrees cause visibility issues
+
+### Evidence from Previous Architecture
+
+The legacy `hestai-core` worktree+symlink architecture caused:
+- **Symlink commit failures**: "symbolic link restrictions" errors
+- **Agent visibility problems**: Files invisible to `git ls-files`, can't `@tag`
+- **Multi-agent conflicts**: No single writer enforcement
+- **Governance drift**: System rules duplicated and diverging across projects
+
+### Core Insight
+
+The worktree architecture traded **visibility for isolation** - but visibility is essential for AI agents, while the isolation benefits never materialized.
+
+**Solution**: Separate concerns into two distinct layers with different delivery mechanisms.
+
+---
+
+## Decision
+
+Implement a **Dual-Layer Context Architecture**:
+
+| Layer | Content | Delivery | Git Status | Writer |
+|-------|---------|----------|------------|--------|
+| **System Governance** | Rules, agents, methodology | MCP server injection | NOT committed | HestAI system |
+| **Project Documentation** | Context, sessions, reports | Direct files | Committed | System Steward only |
+
+### Layer 1: System Governance (Delivered Package)
+
+System governance is treated as **installed software**, not editable files:
+
+```
+.hestai/
+├── .sys-runtime/                    # Delivered by MCP server at activation
+│   ├── governance/
+│   │   ├── rules/
+│   │   │   ├── naming-standard.oct.md
+│   │   │   ├── visibility-rules.oct.md
+│   │   │   └── workflow-methodology.oct.md
+│   │   └── workflow/
+│   │       └── 001-workflow-north-star.oct.md
+│   ├── agents/                      # All agent prompts
+│   │   ├── implementation-lead.oct.md
+│   │   ├── critical-engineer.oct.md
+│   │   ├── system-steward.oct.md
+│   │   └── ... (50+ agents)
+│   ├── templates/                   # System templates
+│   │   └── octave-micro-primer.oct.md
+│   └── .version                     # Hub version marker
+└── .gitignore                       # Ignores .sys-runtime/
+```
+
+**Properties:**
+- **Not git committed** in project repo - delivered at runtime
+- **Immutable during work** - agents read, never modify
+- **Versioned in Hub** - updating HestAI updates governance
+- **No symlinks** - direct file injection by MCP server
+
+### Layer 2: Project Documentation (Living, Single Writer)
+
+Project documentation lives **directly in the repository**, fully visible to agents:
+
+```
+.hestai/
+├── context/                         # Living operational state
+│   ├── project-context.oct.md       # Project dashboard
+│   ├── project-roadmap.oct.md       # Future direction
+│   ├── project-history.oct.md       # Significant events
+│   ├── project-checklist.oct.md     # Current tasks
+│   └── context-negatives.oct.md     # Anti-patterns to avoid
+├── workflow/                        # Project-specific governance
+│   ├── 000-project-north-star.oct.md    # Project immutables
+│   └── decisions/
+│       └── decisions.oct.md         # Architectural rationale
+├── sessions/
+│   ├── active/                      # GITIGNORED (ephemeral)
+│   └── archive/                     # Committed (durable)
+│       ├── 2025-12-19-SESSION_ID.oct.md
+│       └── learnings-index.jsonl
+├── reports/                         # Audit artifacts
+│   └── YYYY-MM-DD-{topic}.oct.md
+└── .sys-runtime/                    # GITIGNORED (delivered)
+```
+
+**Properties:**
+- **Git committed** - visible to agents, `@taggable`, PR reviewable
+- **OCTAVE format** - compressed, structured, parseable
+- **Single writer: System Steward** - all modifications via MCP tools
+- **No direct agent edits** - prevents conflicts
+
+### The Single Writer Pattern
+
+**Critical**: No agent writes to `.hestai/` directly. All writes go through System Steward MCP tools:
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Agent A   │     │   Agent B   │     │   Agent C   │
+└──────┬──────┘     └──────┬──────┘     └──────┬──────┘
+       │                   │                   │
+       │ document_submit   │ context_update    │ document_submit
+       │                   │                   │
+       └───────────────────┼───────────────────┘
+                           │
+                           ▼
+              ┌────────────────────────┐
+              │    System Steward      │
+              │    (MCP Server)        │
+              │                        │
+              │  - Validates format    │
+              │  - Checks conflicts    │
+              │  - Routes to location  │
+              │  - Compresses (OCTAVE) │
+              │  - Commits atomically  │
+              └───────────┬────────────┘
+                          │
+                          ▼
+              ┌────────────────────────┐
+              │  .hestai/context/      │
+              │  .hestai/workflow/     │
+              │  .hestai/sessions/     │
+              │  .hestai/reports/      │
+              └────────────────────────┘
+```
+
+---
+
+## Implementation Status
+
+### Current Implementation (Phase 2.5 Complete)
+
+| Component | Status | Details |
+|-----------|--------|---------|
+| Dual-layer structure | ✅ Complete | .hestai/ direct, .sys-runtime/ planned |
+| Bundled Hub | ✅ Complete | Governance files included in package |
+| MCP Server | ✅ Partial | clock_in/out working, document_submit pending |
+| Single Writer | 🚧 Phase 3 | System Steward tools in progress |
+| Governance Injection | 🚧 Phase 4 | Runtime delivery planned |
+
+### MCP Tools
+
+| Tool | Purpose | Status |
+|------|---------|--------|
+| `clock_in` | Session start, context loading | ✅ Complete |
+| `clock_out` | Session archival, OCTAVE compression | ✅ Complete |
+| `anchor_submit` | Agent identity validation | ✅ Complete |
+| `document_submit` | Route documents to correct location | 🚧 Phase 3 |
+| `context_update` | Merge context changes | 🚧 Phase 3 |
+
+---
+
+## Consequences
+
+### Positive
+
+- **Agent visibility restored**: All project docs in git, taggable
+- **No symlink issues**: Direct files, normal git operations
+- **Conflict prevention**: Single writer pattern eliminates races
+- **Clear mental model**: System = delivered, Project = committed
+- **Governance consistency**: Hub is single source, pushed to projects
+- **OCTAVE standardization**: Compressed, structured, parseable
+
+### Negative
+
+- **Breaking change**: Requires migration from worktree architecture
+- **MCP dependency**: Agents must use tools, not direct writes
+- **Hub requirement**: Bundled governance must be maintained
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Agents bypass System Steward | Pre-commit hook blocks direct `.hestai/` writes |
+| Hub unavailable | Bundled with package, no external dependency |
+| OCTAVE learning curve | System Steward validates and assists |
+
+---
+
+## Validation Criteria
+
+1. **Symlink Issues Resolved**
+   - Agents can commit to `.hestai/` without errors
+   - No "symbolic link restrictions" messages
+
+2. **Agent Visibility**
+   - Files discoverable via `git ls-files`
+   - Can `@tag` files in conversation
+   - Appear in PR diffs
+
+3. **Single Writer Enforced**
+   - All writes go through MCP tools
+   - Pre-commit hook blocks direct writes
+   - No multi-agent conflicts
+
+4. **Governance Delivery**
+   - `.sys-runtime/` populated on MCP start
+   - Agents can read governance without symlinks
+   - Version tracking works
+
+---
+
+## Future Evolution
+
+### Phase 5+: Hub as Application
+
+Transform the Hub from bundled files to an active management system:
+
+1. **Project Registry** - Track all projects using HestAI
+2. **Push Governance** - Update projects from central Hub
+3. **Version Management** - Semantic versioning with breaking change notifications
+4. **Dashboard UI** - Visual project health monitoring
+
+See RFC-0002 for detailed Hub as Application design.
+
+---
+
+## References
+
+- Original ADR-0007 in hestai-core repository
+- OCTAVE Micro Primer: `hub/library/octave/octave-micro-primer.oct.md`
+- Project Roadmap: `.hestai/context/project-roadmap.oct.md`
+
+---
+
+## Decision Record
+
+| Date | Actor | Action |
+|------|-------|--------|
+| 2025-12-19 | User | Identified need for dual-layer architecture |
+| 2025-12-19 | holistic-orchestrator | Adapted ADR-0007 to ADR-0001 |
+| 2025-12-19 | Project Team | ACCEPTED for HestAI-MCP |
+
+---
+
+**END OF ADR-0001**

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -2,6 +2,16 @@
 
 This directory contains proposals and experimental designs for the HestAI MCP system.
 
+## Active RFCs
+
+### [RFC-0001: Context Registry](active/0001-context-registry.md)
+**Status**: EXPERIMENTAL
+Proposes a centralized context registry for managing session and agent contexts across the HestAI ecosystem.
+
+### [RFC-0002: Hub as Application](active/0002-hub-as-application.md)
+**Status**: PROPOSED
+Transform the HestAI Hub from static governance files into an active application with project registry, push capability, and version management.
+
 ## Purpose
 
 - **Experimental Designs**: Ideas and prototypes that aren't ready for production
@@ -15,11 +25,12 @@ rfcs/
 ├── README.md                 # This file
 ├── 0000-template.md          # Template for new RFCs
 ├── active/                   # RFCs under active consideration
-│   └── NNNN-feature-name.md
+│   ├── 0001-context-registry.md
+│   └── 0002-hub-as-application.md
 ├── implemented/              # Accepted and implemented RFCs
-│   └── NNNN-feature-name.md
+│   └── (empty - none yet)
 └── experimental/             # Prototypes and proof-of-concepts
-    └── context-registry/     # Example experimental feature
+    └── 0001-context-registry/    # Experimental registry code
 ```
 
 ## Process
@@ -29,6 +40,16 @@ rfcs/
 3. **Decision**: Accept, reject, or defer
 4. **Implementation**: Move to `implemented/` once built
 5. **Experimental**: Use `experimental/` for code prototypes
+
+## RFC States
+
+- **DRAFT**: Initial proposal being written
+- **PROPOSED**: Ready for discussion
+- **EXPERIMENTAL**: Has proof-of-concept code
+- **ACCEPTED**: Approved for implementation
+- **REJECTED**: Not moving forward
+- **DEFERRED**: Postponed for future consideration
+- **IMPLEMENTED**: Completed and merged
 
 ## Benefits
 
@@ -43,6 +64,7 @@ rfcs/
 - Not included in production builds
 - Can be gitignored if desired
 - Prototypes should be self-contained
+- Deleted after RFC decision (accept or reject)
 
 ## When to Use RFCs
 
@@ -51,3 +73,11 @@ rfcs/
 - Significant architectural changes
 - External API modifications
 - Experimental ideas needing discussion
+
+## Creating a New RFC
+
+1. Copy `0000-template.md` to `active/NNNN-title.md`
+2. Fill out all sections completely
+3. Submit PR for discussion
+4. Optional: Add experimental code to `experimental/NNNN-title/`
+5. Update this README to list your RFC

--- a/rfcs/active/0002-hub-as-application.md
+++ b/rfcs/active/0002-hub-as-application.md
@@ -1,0 +1,209 @@
+# RFC-0002: Hub as Application
+
+**Status**: PROPOSED
+**Created**: 2025-12-19
+**Author**: holistic-orchestrator
+
+## Summary
+
+Transform the HestAI Hub from a static collection of governance files into an active application that manages governance distribution, version tracking, and project health monitoring across all HestAI-enabled projects.
+
+## Motivation
+
+Currently, the Hub is bundled as static files within the HestAI-MCP package. While this works for single projects, it creates challenges for:
+
+1. **Multi-project governance** - Each project has its own copy of governance files
+2. **Version drift** - No central tracking of which projects use which governance versions
+3. **Update distribution** - Manual process to update governance across projects
+4. **Project visibility** - No dashboard showing health/status of all projects
+5. **Breaking changes** - No mechanism to notify projects of governance updates
+
+## Detailed Design
+
+### Phase 1: Project Registry
+
+Create a central registry of all projects using HestAI:
+
+```python
+# hub/registry.json
+{
+  "projects": {
+    "eav-monorepo": {
+      "path": "/Volumes/HestAI-Projects/eav-monorepo",
+      "governance_version": "1.2.0",
+      "last_sync": "2025-12-19T10:00:00Z",
+      "phase": "B2",
+      "health": "green"
+    },
+    "copy-editor": {
+      "path": "/Volumes/HestAI-Projects/copy-editor",
+      "governance_version": "1.1.0",
+      "last_sync": "2025-12-18T15:00:00Z",
+      "phase": "B3",
+      "health": "yellow"  // Outdated governance
+    }
+  }
+}
+```
+
+### Phase 2: Push Governance Capability
+
+Implement commands to push governance updates to projects:
+
+```bash
+# Push to single project
+hestai governance push --project eav-monorepo
+
+# Push to all projects
+hestai governance push --all
+
+# Dry run to see what would change
+hestai governance push --project copy-editor --dry-run
+
+# Push with breaking change warning
+hestai governance push --version 2.0.0 --breaking
+```
+
+Implementation:
+```python
+class GovernanceManager:
+    def push_governance(self, project_name: str, version: str = "latest"):
+        """Push governance files to project's .sys-runtime/"""
+        project = self.registry.get_project(project_name)
+
+        # Check version compatibility
+        if self.has_breaking_changes(project.governance_version, version):
+            if not self.confirm_breaking_changes():
+                return
+
+        # Copy governance files
+        source = self.hub_path / "governance"
+        target = Path(project.path) / ".hestai" / ".sys-runtime"
+
+        # Clear and repopulate
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(source, target)
+
+        # Update registry
+        project.governance_version = version
+        project.last_sync = datetime.now()
+        self.registry.save()
+```
+
+### Phase 3: Version Management
+
+Implement semantic versioning for governance:
+
+```yaml
+# hub/governance/version.yaml
+version: 1.2.0
+changelog:
+  1.2.0:
+    date: 2025-12-19
+    changes:
+      - Added new agent: performance-analyst
+      - Updated naming-standard.oct.md
+    breaking: false
+
+  2.0.0:
+    date: 2025-12-25
+    changes:
+      - Restructured agent architecture
+      - New OCTAVE v5 format
+    breaking: true
+    migration_guide: docs/migration/v2.md
+```
+
+### Phase 4: Dashboard UI (Future)
+
+Create a web dashboard for project health monitoring:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                  HestAI Project Dashboard               │
+├─────────────────────────────────────────────────────────┤
+│                                                          │
+│  Project         Phase  Gov Ver  Health  Last Sync      │
+│  ─────────────────────────────────────────────────      │
+│  eav-monorepo    B2    1.2.0    ✅      2 hours ago    │
+│  copy-editor     B3    1.1.0    ⚠️      2 days ago     │
+│  scenes-web      B1    1.2.0    ✅      1 hour ago     │
+│                                                          │
+│  [Push All Updates]  [Check Health]  [View Changelog]   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Implementation Plan
+
+### Milestone 1: Registry (Week 1)
+- [ ] Create project registry schema
+- [ ] Implement registration commands
+- [ ] Add project discovery mechanism
+
+### Milestone 2: Push Capability (Week 2)
+- [ ] Implement governance push command
+- [ ] Add version compatibility checking
+- [ ] Create dry-run mode
+
+### Milestone 3: Version Management (Week 3)
+- [ ] Implement semantic versioning
+- [ ] Add changelog generation
+- [ ] Create breaking change notifications
+
+### Milestone 4: Dashboard (Future)
+- [ ] Design web UI
+- [ ] Implement health checks
+- [ ] Add real-time monitoring
+
+## Alternatives Considered
+
+### Alternative 1: Git Submodules
+Use git submodules to share governance across projects.
+- **Pros**: Native git support, version pinning
+- **Cons**: Complex for users, merge conflicts, poor ergonomics
+
+### Alternative 2: NPM Package
+Distribute governance as an NPM package.
+- **Pros**: Standard package management, version control
+- **Cons**: Language-specific, requires package.json in all projects
+
+### Alternative 3: Symbolic Links
+Use symlinks to shared governance directory.
+- **Pros**: Simple, real-time updates
+- **Cons**: Platform issues, breaks with moves, no versioning
+
+## Open Questions
+
+1. **Authentication**: Should push operations require authentication?
+2. **Rollback**: How to handle governance rollback if issues occur?
+3. **Customization**: Can projects override specific governance rules?
+4. **CI Integration**: How to integrate with CI/CD pipelines?
+5. **Multi-machine**: How to sync registry across developer machines?
+
+## Security Considerations
+
+- **Write Protection**: Only authorized users can push governance
+- **Audit Trail**: Log all governance updates with who/when/what
+- **Validation**: Verify governance files before distribution
+- **Backup**: Automatic backup before overwriting .sys-runtime/
+
+## Success Metrics
+
+1. **Adoption Rate**: % of projects using latest governance within 7 days
+2. **Update Frequency**: Average time between governance updates
+3. **Error Rate**: Failed push operations / total pushes
+4. **User Satisfaction**: Developer survey on governance management
+
+## Unresolved Questions
+
+- Should the registry be stored in git or as a separate database?
+- How to handle projects on different machines/networks?
+- What's the migration path for existing projects?
+- Should there be a "governance freeze" mechanism for production?
+
+## References
+
+- [ADR-0001: Dual-Layer Context Architecture](../docs/adr/adr-0001-dual-layer-context-architecture.md)
+- [HestAI Hub Repository](https://github.com/elevanaltd/HestAI)
+- [MCP Specification](https://modelcontextprotocol.io/)


### PR DESCRIPTION
## Summary

Adds foundational architecture documentation and future vision for HestAI-MCP.

## Changes

### Architecture Decision Records (ADRs)
- **ADR-0001**: Dual-Layer Context Architecture
  - Adapted from hestai-core ADR-0007
  - Documents our foundational architecture decision
  - Explains the dual-layer approach (System Governance vs Project Documentation)
  - Details the single writer pattern to prevent conflicts
  - Includes current implementation status

### Request for Comments (RFCs)
- **RFC-0002**: Hub as Application
  - Vision for Phase 5+ evolution
  - Project registry for multi-project governance
  - Push capability for governance distribution
  - Version management with semantic versioning
  - Future dashboard UI for project health monitoring

### Documentation Updates
- Updated RFC README with active RFCs listing
- Clear RFC process and state definitions

## Context

This PR establishes the documented vision for the project's architecture and future evolution beyond Phase 4. It addresses the gap identified where the vision existed in discussions and other repos but wasn't formally captured in this project.

## Test Plan

- [x] Documentation renders correctly
- [x] All links work properly
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)