### PR TITLE
chore: rename .sys-runtime to .hestai-sys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # System Governance (Delivered by MCP, NOT committed)
-.hestai/.sys-runtime/
+.hestai-sys/
 
 # Active Sessions (Ephemeral)
 .hestai/sessions/active/

--- a/.hestai/context/PROJECT-CHECKLIST.oct.md
+++ b/.hestai/context/PROJECT-CHECKLIST.oct.md
@@ -15,7 +15,7 @@ PHASE_0_FOUNDATION:
     main_branch_rename::DONE[feat/phase-0-foundation]
     OCTAVE_context_files::DONE[PROJECT-CONTEXT,PROJECT-CHECKLIST,PROJECT-ROADMAP]
     pyproject_toml::DONE[with_dev_dependencies]
-    gitignore_creation::DONE[.sys-runtime_excluded,sessions/active_excluded]
+    gitignore_creation::DONE[.hestai-sys_excluded,sessions/active_excluded]
     README_initial::DONE
 
 PHASE_1_CODE_PORTING:
@@ -69,7 +69,7 @@ PHASE_2_MCP_SERVER:
   TASKS:
     server_creation::DONE[server.py_181_lines]
     tool_registration::DONE[clock_in,clock_out]
-    sys_runtime_stub::DONE[inject_system_governance_function]
+    hestai_sys_stub::DONE[inject_system_governance_function]
     document_submit_placeholder::DONE[TODO_Phase_3_marker]
 
 QUALITY_GATES:
@@ -100,7 +100,7 @@ VERIFICATION_COMPLETE:
     no_symlinks::.hestai/[CONFIRMED_direct_directory]
     no_worktrees::CONFIRMED[single_repo_architecture]
     OCTAVE_format::CONFIRMED[all_context_files]
-    gitignore_sys_runtime::CONFIRMED[.hestai/.sys-runtime/]
+    gitignore_hestai_sys::CONFIRMED[.hestai-sys/]
     gitignore_active_sessions::CONFIRMED[.hestai/sessions/active/]
 
   CODE_PORTING::VERIFIED:
@@ -128,7 +128,7 @@ NEXT_ACTIONS:
   ]
 
   PHASE_4::[
-    implement_sys_runtime_governance_injection,
+    implement_hestai_sys_governance_injection,
     implement_HESTAI_HUB_ROOT_environment_handling,
     create_pre_commit_hook_blocking_direct_.hestai_writes
   ]

--- a/.hestai/context/PROJECT-CONTEXT.oct.md
+++ b/.hestai/context/PROJECT-CONTEXT.oct.md
@@ -10,7 +10,7 @@ META:
 PURPOSE::"MCP server implementing dual-layer context architecture for AI agent coordination"
 
 ARCHITECTURE::DUAL_LAYER:
-  SYSTEM_GOVERNANCE::.sys-runtime/[delivered_not_committed]
+  SYSTEM_GOVERNANCE::.hestai-sys/[delivered_not_committed]
   PROJECT_DOCUMENTATION::.hestai/[committed_single_writer]
 
 ACTIVE_WORK::[
@@ -36,7 +36,7 @@ KEY_INSIGHTS::[
   NO_SYMLINKS::"Direct .hestai/ directory for git visibility",
   SINGLE_WRITER::"System Steward MCP tools only write to .hestai/",
   OCTAVE_STANDARD::"All context in OCTAVE format for compression+structure",
-  DELIVERED_GOVERNANCE::".sys-runtime/ injected by MCP server not committed"
+  DELIVERED_GOVERNANCE::".hestai-sys/ injected by MCP server not committed"
 ]
 
 BLOCKERS::none
@@ -53,7 +53,7 @@ NEXT_ACTIONS::[
   1::Port_additional_tests_from_hestai_core_for_ported_modules,
   2::Implement_document_submit_tool[Phase_3],
   3::Implement_context_update_tool[Phase_3],
-  4::Implement_sys_runtime_governance_injection[Phase_4],
+  4::Implement_hestai_sys_governance_injection[Phase_4],
   5::Create_pre_commit_hook_blocking_direct_.hestai_writes
 ]
 

--- a/.hestai/context/PROJECT-ROADMAP.oct.md
+++ b/.hestai/context/PROJECT-ROADMAP.oct.md
@@ -49,7 +49,7 @@ PHASES:
       ✅::tool_registration[clock_in+clock_out],
       ✅::clock_in_functional,
       ✅::clock_out_functional,
-      ✅::sys_runtime_injection_stub,
+      ✅::hestai_sys_injection_stub,
       ✅::document_submit_placeholder
     ]
     QUALITY::[
@@ -84,10 +84,10 @@ PHASES:
     STATUS::pending
 
   PHASE_4::GOVERNANCE_DELIVERY[days:11-14]:
-    GOAL::".sys-runtime/ injection from bundled Hub"
+    GOAL::".hestai-sys/ injection from bundled Hub"
     DELIVERABLES::[
       ✅::bundled_hub_architecture[no_external_dependency],
-      sys_runtime_population_on_startup[inject_system_governance()],
+      hestai_sys_population_on_startup[inject_system_governance()],
       ✅::version_tracking[hub/VERSION_1.0.0],
       governance_file_injection_to_projects
     ]
@@ -105,7 +105,7 @@ MILESTONES:
   PRODUCTION_READY::[
     document_submit_routing,
     single_writer_enforced,
-    sys_runtime_delivered,
+    hestai_sys_delivered,
     pre_commit_hooks_blocking_direct_writes
   ]
   STATUS::pending_phase_3_and_4

--- a/.hestai/reports/2025-12-19-system-steward-phase-0-2-review.oct.md
+++ b/.hestai/reports/2025-12-19-system-steward-phase-0-2-review.oct.md
@@ -21,7 +21,7 @@ EXECUTIVE_SUMMARY:
 ARCHITECTURE_VERIFICATION:
   dual_layer_structure::VERIFIED:
     .hestai_directory::PRESENT[direct_not_symlink]
-    .sys_runtime_placeholder::PLANNED[Phase_4]
+    .hestai_sys_placeholder::PLANNED[Phase_4]
     context_files::PRESENT[OCTAVE_format]
     sessions_structure::PRESENT[active,archive]
     reports_directory::PRESENT
@@ -38,7 +38,7 @@ ARCHITECTURE_VERIFICATION:
     anchor_manager::EXCLUDED_from_port
 
   gitignore_compliance::VERIFIED:
-    .sys_runtime_excluded::CONFIRMED[not_committed]
+    .hestai_sys_excluded::CONFIRMED[not_committed]
     sessions_active_excluded::CONFIRMED[ephemeral]
     python_artifacts_excluded::CONFIRMED
     venv_excluded::CONFIRMED
@@ -100,7 +100,7 @@ FINDING::CODE_PORTING_EXCELLENT
 SERVER_VERIFICATION:
   server_file::src/hestai_mcp/mcp/server.py[181_lines]
   tools_registered::[clock_in,clock_out]
-  sys_runtime_stub::inject_system_governance[TODO_Phase_4]
+  hestai_sys_stub::inject_system_governance[TODO_Phase_4]
   document_submit_placeholder::TODO_Phase_3
 
 TOOL_REGISTRATION_VERIFICATION:
@@ -215,7 +215,7 @@ SHORT_TERM_ACTIONS:
   4::implement_OCTAVE_validation
 
 MEDIUM_TERM_ACTIONS:
-  1::implement_sys_runtime_governance_injection[Phase_4]
+  1::implement_hestai_sys_governance_injection[Phase_4]
   2::implement_HESTAI_HUB_ROOT_environment_handling
   3::create_pre_commit_hook_blocking_direct_.hestai_writes
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ HestAI-MCP treats system governance (rules, agent definitions, workflows) as **i
 *   **Instant updates** when you upgrade the MCP server.
 
 It implements a **Dual-Layer Context Architecture** (see [Architecture](docs/ARCHITECTURE.md)):
-1.  **System Governance** (`.sys-runtime/`): Injected at runtime, read-only.
+1.  **System Governance** (`.hestai-sys/`): Injected at runtime, read-only.
 2.  **Project Documentation** (`.hestai/`): Living project context, committed to git.
 
 ## Architecture

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Defined in [ADR-0001](adr/adr-0001-dual-layer-context-architecture.md), the syst
 ```mermaid
 graph TD
     subgraph "System Governance (Layer 1)"
-        Hub[HestAI Hub] -->|MCP Injection| Runtime[.sys-runtime/]
+        Hub[HestAI Hub] -->|MCP Injection| Runtime[.hestai-sys/]
         Runtime --> Rules[Rules & Standards]
         Runtime --> Agents[Agent Definitions]
         style Runtime fill:#f9f,stroke:#333,stroke-dasharray: 5 5
@@ -113,8 +113,8 @@ your-project/
 ├── .hestai/                    # Project documentation (committed)
 │   ├── context/                # Living operational state
 │   ├── sessions/               # Session transcripts
-│   ├── workflow/               # Project-specific rules
-│   └── .sys-runtime/           # System governance (gitignored, injected)
+│   └── workflow/               # Project-specific rules
+├── .hestai-sys/                # System governance (gitignored, injected)
 ├── docs/
 │   ├── adr/                    # Architecture Decision Records
 │   └── CHANGELOG.md            # CI-updated audit trail

--- a/docs/adr/adr-0001-dual-layer-context-architecture.md
+++ b/docs/adr/adr-0001-dual-layer-context-architecture.md
@@ -48,24 +48,22 @@ Implement a **Dual-Layer Context Architecture**:
 System governance is treated as **installed software**, not editable files:
 
 ```
-.hestai/
-├── .sys-runtime/                    # Delivered by MCP server at activation
-│   ├── governance/
-│   │   ├── rules/
-│   │   │   ├── naming-standard.oct.md
-│   │   │   ├── visibility-rules.oct.md
-│   │   │   └── workflow-methodology.oct.md
-│   │   └── workflow/
-│   │       └── 001-workflow-north-star.oct.md
-│   ├── agents/                      # All agent prompts
-│   │   ├── implementation-lead.oct.md
-│   │   ├── critical-engineer.oct.md
-│   │   ├── system-steward.oct.md
-│   │   └── ... (50+ agents)
-│   ├── templates/                   # System templates
-│   │   └── octave-micro-primer.oct.md
-│   └── .version                     # Hub version marker
-└── .gitignore                       # Ignores .sys-runtime/
+.hestai-sys/                          # Delivered by MCP server at activation
+├── governance/
+│   ├── rules/
+│   │   ├── naming-standard.oct.md
+│   │   ├── visibility-rules.oct.md
+│   │   └── workflow-methodology.oct.md
+│   └── workflow/
+│       └── 001-workflow-north-star.oct.md
+├── agents/                            # All agent prompts
+│   ├── implementation-lead.oct.md
+│   ├── critical-engineer.oct.md
+│   ├── system-steward.oct.md
+│   └── ... (50+ agents)
+├── templates/                         # System templates
+│   └── octave-micro-primer.oct.md
+└── .version                           # Hub version marker
 ```
 
 **Properties:**
@@ -97,8 +95,9 @@ Project documentation lives **directly in the repository**, fully visible to age
 │       └── learnings-index.jsonl
 ├── reports/                         # Audit artifacts
 │   └── YYYY-MM-DD-{topic}.oct.md
-└── .sys-runtime/                    # GITIGNORED (delivered)
 ```
+
+System governance is injected to `.hestai-sys/` (top-level, gitignored) by the MCP server.
 
 **Properties:**
 - **Git committed** - visible to agents, `@taggable`, PR reviewable
@@ -148,7 +147,7 @@ Project documentation lives **directly in the repository**, fully visible to age
 
 | Component | Status | Details |
 |-----------|--------|---------|
-| Dual-layer structure | ✅ Complete | .hestai/ direct, .sys-runtime/ planned |
+|| Dual-layer structure | ✅ Complete | .hestai/ direct, .hestai-sys/ planned |
 | Bundled Hub | ✅ Complete | Governance files included in package |
 | MCP Server | ✅ Partial | clock_in/out working, document_submit pending |
 | Single Writer | 🚧 Phase 3 | System Steward tools in progress |
@@ -210,7 +209,7 @@ Project documentation lives **directly in the repository**, fully visible to age
    - No multi-agent conflicts
 
 4. **Governance Delivery**
-   - `.sys-runtime/` populated on MCP start
+   - `.hestai-sys/` populated on MCP start
    - Agents can read governance without symlinks
    - Version tracking works
 

--- a/hub/tools/check_octave_v4.py
+++ b/hub/tools/check_octave_v4.py
@@ -30,7 +30,9 @@ def is_octave_v4_compliant(path: str) -> tuple[bool, list[str]]:
 
     # first/last non-empty
     first = next((i for i, line in enumerate(lines) if line.strip() != ""), None)
-    last = next((len(lines) - 1 - i for i, line in enumerate(reversed(lines)) if line.strip() != ""), None)
+    last = next(
+        (len(lines) - 1 - i for i, line in enumerate(reversed(lines)) if line.strip() != ""), None
+    )
 
     if first is None or not HEADER_RE.match(lines[first]):
         issues.append("header:missing_or_invalid")

--- a/rfcs/active/0002-hub-as-application.md
+++ b/rfcs/active/0002-hub-as-application.md
@@ -68,7 +68,7 @@ Implementation:
 ```python
 class GovernanceManager:
     def push_governance(self, project_name: str, version: str = "latest"):
-        """Push governance files to project's .sys-runtime/"""
+        """Push governance files to project's .hestai-sys/"""
         project = self.registry.get_project(project_name)
 
         # Check version compatibility
@@ -78,7 +78,7 @@ class GovernanceManager:
 
         # Copy governance files
         source = self.hub_path / "governance"
-        target = Path(project.path) / ".hestai" / ".sys-runtime"
+        target = Path(project.path) / ".hestai-sys"
 
         # Clear and repopulate
         if target.exists():
@@ -186,7 +186,7 @@ Use symlinks to shared governance directory.
 - **Write Protection**: Only authorized users can push governance
 - **Audit Trail**: Log all governance updates with who/when/what
 - **Validation**: Verify governance files before distribution
-- **Backup**: Automatic backup before overwriting .sys-runtime/
+- **Backup**: Automatic backup before overwriting .hestai-sys/
 
 ## Success Metrics
 

--- a/rfcs/experimental/0001-context-registry/clock_in_enhanced.py
+++ b/rfcs/experimental/0001-context-registry/clock_in_enhanced.py
@@ -157,7 +157,9 @@ def demo_registry_benefits(working_dir: str) -> None:
         avg_tokens_per_doc = 500
         total_tokens = metadata["total_available"] * avg_tokens_per_doc
         loaded_tokens = metadata["loaded"] * avg_tokens_per_doc
-        savings_pct = ((total_tokens - loaded_tokens) / total_tokens * 100) if total_tokens > 0 else 0
+        savings_pct = (
+            ((total_tokens - loaded_tokens) / total_tokens * 100) if total_tokens > 0 else 0
+        )
 
         print(f"\nEstimated Token Savings: {savings_pct:.1f}%")
         print(f"  Without Registry: ~{total_tokens} tokens")

--- a/src/hestai_mcp/mcp/server.py
+++ b/src/hestai_mcp/mcp/server.py
@@ -7,7 +7,7 @@ This MCP server provides context management tools for AI agents:
 - document_submit: Submit documents to .hestai/ (TODO - Phase 3)
 
 Architecture:
-- System Governance: .sys-runtime/ delivered by MCP (not committed)
+- System Governance: .hestai-sys/ delivered by MCP (not committed)
 - Project Documentation: .hestai/ committed (single writer via MCP tools)
 - Hub: Bundled with MCP server package (no external HESTAI_HUB_ROOT dependency)
 """
@@ -72,7 +72,7 @@ def get_hub_version() -> str:
 
 def inject_system_governance(project_root: Path) -> None:
     """
-    Inject system governance files into .hestai/.sys-runtime/.
+    Inject system governance files into .hestai-sys/.
 
     ADR-0007: System governance is delivered by MCP server at startup,
     not committed to git. This provides agents, rules, and templates.
@@ -83,16 +83,16 @@ def inject_system_governance(project_root: Path) -> None:
     Args:
         project_root: Project root directory
     """
-    sys_runtime = project_root / ".hestai" / ".sys-runtime"
+    hestai_sys_dir = project_root / ".hestai-sys"
     hub_path = get_hub_path()
 
-    # Create .sys-runtime directory if it doesn't exist
-    sys_runtime.mkdir(parents=True, exist_ok=True)
+    # Create .hestai-sys directory if it doesn't exist
+    hestai_sys_dir.mkdir(parents=True, exist_ok=True)
 
     # Copy governance files from bundled hub
     for source_dir in ["governance", "agents", "library", "templates"]:
         source = hub_path / source_dir
-        dest = sys_runtime / source_dir
+        dest = hestai_sys_dir / source_dir
 
         if source.exists():
             # Remove existing destination to ensure clean copy
@@ -102,9 +102,9 @@ def inject_system_governance(project_root: Path) -> None:
             logger.info(f"Copied {source_dir} from bundled hub to {dest}")
 
     # Write version marker
-    version_file = sys_runtime / ".version"
+    version_file = hestai_sys_dir / ".version"
     version_file.write_text(get_hub_version())
-    logger.info(f"Injected system governance v{get_hub_version()} to {sys_runtime}")
+    logger.info(f"Injected system governance v{get_hub_version()} to {hestai_sys_dir}")
 
 
 @app.list_tools()
@@ -219,7 +219,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         project_root = None
 
         for root in possible_roots:
-            potential_session = root / ".hestai" / "sessions" / "active" / session_id / "session.json"
+            potential_session = (
+                root / ".hestai" / "sessions" / "active" / session_id / "session.json"
+            )
             if potential_session.exists():
                 session_file = potential_session
                 project_root = root

--- a/src/hestai_mcp/mcp/tools/shared/security.py
+++ b/src/hestai_mcp/mcp/tools/shared/security.py
@@ -108,7 +108,10 @@ class RedactionEngine:
         # This prevents loading multi-MB session files entirely into memory
         # Fail-closed: if redaction fails, clean up partial output
         try:
-            with open(src, encoding="utf-8") as src_file, open(dst, "w", encoding="utf-8") as dst_file:
+            with (
+                open(src, encoding="utf-8") as src_file,
+                open(dst, "w", encoding="utf-8") as dst_file,
+            ):
                 for line in src_file:
                     redacted_line = cls.redact_content(line)
                     dst_file.write(redacted_line)

--- a/tests/unit/mcp/tools/shared/test_security.py
+++ b/tests/unit/mcp/tools/shared/test_security.py
@@ -137,9 +137,12 @@ class TestCopyAndRedact:
         dst = tmp_path / "archive.jsonl"
 
         # Simulate redaction failure mid-copy
-        with patch.object(
-            RedactionEngine, "redact_content", side_effect=Exception("Redaction failed")
-        ), pytest.raises(Exception, match="Redaction failed"):
+        with (
+            patch.object(
+                RedactionEngine, "redact_content", side_effect=Exception("Redaction failed")
+            ),
+            pytest.raises(Exception, match="Redaction failed"),
+        ):
             RedactionEngine.copy_and_redact(src, dst)
 
         # Verify destination cleaned up


### PR DESCRIPTION
Renames the injected system governance directory from `.sys-runtime/` to `.hestai-sys/` across docs, OCTAVE context, gitignore, and MCP injection code.

Notes:
- `.hestai-sys/` is top-level and gitignored (delivered at runtime).
- Quality gates: pytest/ruff/mypy/black passing in worktree venv.

Co-Authored-By: Warp <agent@warp.dev>
