### PR TITLE
docs: align sessions + living artifacts with current repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,3 @@ dmypy.json
 # Git worktrees (Crystal)
 /worktrees/
 /worktree-*/
-.hestai/sessions/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ graph TD
 | Layer | Content | Delivery | Git Status | Writer |
 |-------|---------|----------|------------|--------|
 | **System Governance** | Rules, agents, methodology | MCP server injection | `.gitignore` | HestAI system |
-| **Project Documentation** | Context, sessions, reports | Direct files | Committed | System Steward only |
+| **Project Documentation** | Context, sessions (active ignored, archive committed), reports | Direct files | Committed (except active sessions) | System Steward only |
 
 ---
 


### PR DESCRIPTION
Fixes inconsistencies after the `.hestai-sys/` rename merge:

- Stop ignoring all of `.hestai/sessions/` so archive sessions can be committed; keep `.hestai/sessions/active/` ignored.
- Clarify in docs/ARCHITECTURE.md that active sessions are ignored and archive sessions are committed.
- Update ADR-0003 to remove outdated symlink/orphan-branch assumptions and align with current repo structure.

Co-Authored-By: Warp <agent@warp.dev>
