### PR TITLE
chore(pre-commit): add ADR/RFC numbering validation hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
         pass_filenames: false
         always_run: true
 
+      - id: adr-rfc-numbering
+        name: Validate ADR/RFC numbering matches GitHub Issue
+        entry: bash -c 'set -euo pipefail; if git diff --cached --name-only --diff-filter=ACMR | grep -E "^(docs/adr/adr-|rfcs/active/)" >/dev/null; then bash scripts/ci/validate-doc-numbering.sh; else echo "SKIP doc numbering (no ADR/RFC staged)"; fi'
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: ruff
         name: ruff (staged)
         entry: ruff check


### PR DESCRIPTION
## Summary

Adds pre-commit hook that validates ADR and RFC filenames match their GitHub Issue numbers per RFC-0031.

### Changes
- Added `adr-rfc-numbering` hook to `.pre-commit-config.yaml`
- Runs `scripts/ci/validate-doc-numbering.sh` when ADR/RFC files are staged
- Catches numbering mismatches locally before push

### Root Cause (RCCAFP Triage: QUICK_FIX)

The ADR-0047 vs Issue #56 mismatch was caught by CI but not locally. This gap allowed the error to reach the remote before detection.

| Factor | Description |
|--------|-------------|
| **Convention Invisibility** | RFC-0031 numbering convention wasn't in agent context |
| **No Local Validation** | CI had the check, pre-commit didn't |
| **Sequential Assumption** | Agent defaulted to 0046→0047 instead of matching issue |

### Future-Proofing Implemented

| Layer | Prevention |
|-------|------------|
| **Pre-commit** | `adr-rfc-numbering` hook validates at commit time |
| **Skill** | `documentation-placement` updated with §20b ADR_NUMBERING_CONVENTION |
| **CI** | Already existed (caught this issue) |

## Test Plan

- [x] Pre-commit hook triggers on ADR/RFC file changes
- [x] Hook correctly skips when no ADR/RFC files staged
- [x] Validates existing ADRs pass (no false positives)

## Related

- Issue #57: RCCAFP triage protocol integration
- RFC-0031: GitHub Issue-Based Document Numbering
- Previous: PR #52 (FAST layer implementation, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)