### PR TITLE
chore: gitignore debates/ for tiered lifecycle pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ dmypy.json
 # Git worktrees (Crystal)
 /worktrees/
 /worktree-*/
+
+# Debates (local development - per tiered lifecycle decision)
+# Existing committed debates remain as historical decision records
+# Future debates are ephemeral by default
+debates/


### PR DESCRIPTION
## Summary
- Adds `debates/` to .gitignore following Wind-Wall-Door debate conclusion
- Existing committed debate files remain in history as decision records
- Future debates are local development artifacts (TIER 1: ephemeral)

## Context
Per structured debate with Wind (Gemini), Wall (Codex), and Door (Claude):
- **Wind** explored cognitive memory vs ephemeral artifacts tradeoffs
- **Wall** provided evidence: GitHub size limits, security risks (PII/secrets in transcripts), industry precedent (MLflow, DVC, W&B all use external artifact stores)
- **Door** synthesized: Tiered Lifecycle Pattern

## The Pattern
| Tier | Location | Status | Purpose |
|------|----------|--------|---------|
| TIER 1 | `debates/` | Gitignored | Ephemeral local development |
| TIER 2 | `docs/decisions/` | Committed | Curated decision summaries |
| TIER 3 | External store | Reference | Full archive for forensics |

## Cross-Repo Consistency
- debate-hall-mcp: Already gitignores debates/ ✓
- OCTAVE: Now gitignores debates/ (committed in 3f11a4d)
- HestAI-MCP: This PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)