### PR TITLE
fix(ci): detect root-level docs violating visibility rules

### DIFF
--- a/scripts/ci/validate_naming_visibility.py
+++ b/scripts/ci/validate_naming_visibility.py
@@ -87,12 +87,22 @@ def main(argv: list[str]) -> int:
     if args.staged:
         paths = _staged_files()
 
-    docs = [p for p in paths if _is_doc(p) and _is_allowed_root(p)]
+    docs = [p for p in paths if _is_doc(p)]
     if not docs:
         print("SKIP naming/visibility (no relevant docs)")
         return 0
 
     for p in docs:
+        if not _is_allowed_root(p):
+            # Root-level doc file - check if whitelisted
+            name = Path(p).name
+            if not RE_WHITELIST.match(name):
+                raise SystemExit(
+                    f"ERROR visibility-rules: Root-level doc '{p}' not allowed. "
+                    f"Move to docs/, .hestai/, .claude/, or hub/ per visibility-rules.oct.md"
+                )
+            # Whitelisted root files pass without further validation
+            continue
         _validate_one(p)
 
     print("OK naming/visibility")

--- a/tests/test_validate_naming_visibility.py
+++ b/tests/test_validate_naming_visibility.py
@@ -1,0 +1,91 @@
+"""Tests for validate_naming_visibility.py - Issue #68 fix.
+
+Tests the root-level file blind spot fix where non-whitelisted root-level
+.md files should be rejected with clear guidance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestRootLevelDocValidation:
+    """Test cases for root-level document validation behavior."""
+
+    def test_root_readme_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """README.md at root should pass validation (whitelisted)."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # README.md is in RE_WHITELIST, should pass
+        result = main(["README.md"])
+        assert result == 0
+
+    def test_root_claude_md_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CLAUDE.md at root should pass validation (whitelisted)."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # CLAUDE.md is in RE_WHITELIST, should pass
+        result = main(["CLAUDE.md"])
+        assert result == 0
+
+    def test_root_arbitrary_md_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """PHASE_4_COMPLETION.md at root should fail with visibility error."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # Arbitrary root-level .md file not in whitelist should fail
+        with pytest.raises(SystemExit) as exc_info:
+            main(["PHASE_4_COMPLETION.md"])
+
+        error_message = str(exc_info.value)
+        assert "visibility-rules" in error_message.lower() or "root-level" in error_message.lower()
+
+    def test_docs_valid_md_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """docs/valid-name.md should pass validation."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # Files in docs/ with valid naming should pass
+        result = main(["docs/valid-name.md"])
+        assert result == 0
+
+    def test_root_changelog_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CHANGELOG.md at root should pass validation (whitelisted)."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # CHANGELOG.md is in RE_WHITELIST, should pass
+        result = main(["CHANGELOG.md"])
+        assert result == 0
+
+    def test_root_contributing_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CONTRIBUTING.md at root should pass validation (whitelisted)."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # CONTRIBUTING.md is in RE_WHITELIST, should pass
+        result = main(["CONTRIBUTING.md"])
+        assert result == 0
+
+    def test_root_random_uppercase_md_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RANDOM-UPPERCASE-FILE.md at root should fail."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # Random uppercase file not in whitelist should fail
+        with pytest.raises(SystemExit) as exc_info:
+            main(["RANDOM-UPPERCASE-FILE.md"])
+
+        error_message = str(exc_info.value)
+        assert "visibility-rules" in error_message.lower() or "root-level" in error_message.lower()
+
+    def test_hestai_context_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """.hestai/ files should pass through to standard validation."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # Files in .hestai/ should pass if they follow naming rules
+        result = main([".hestai/context/PROJECT-CONTEXT.md"])
+        assert result == 0
+
+    def test_hub_governance_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """hub/ files should pass through to standard validation."""
+        from scripts.ci.validate_naming_visibility import main
+
+        # Files in hub/ should pass if they follow naming rules
+        result = main(["hub/governance/rules/naming-standard.oct.md"])
+        assert result == 0


### PR DESCRIPTION
## Summary
- Root-level `.md` files (except whitelisted: README, CLAUDE, etc.) now fail validation with guidance to correct placement
- Previously, line 90 silently filtered out root-level files with `_is_allowed_root()`, causing them to bypass all validation
- Now explicitly validates all doc files and rejects non-whitelisted root files with actionable error message

## Test plan
- [x] 9 new tests added covering root validation behavior
- [x] `test_root_readme_passes` - README.md at root passes
- [x] `test_root_arbitrary_md_fails` - Non-whitelisted root .md fails with guidance
- [x] `test_docs_valid_md_passes` - Files in allowed directories still work
- [x] All quality gates pass (pytest, ruff, black, mypy)

## Quality Evidence
```
pytest: 9/9 tests pass
ruff check: All checks passed
black --check: 2 files unchanged
mypy: Success, no issues found
```

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)