### PR TITLE
chore: add Claude Code and clipboard cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Claude Code configuration and state (local user settings)
+.claude/
+
+# Gemini clipboard cache (temporary clipboard artifacts)
+.gemini-clipboard/
+
 # System Governance (Delivered by MCP, NOT committed)
 .hestai-sys/
 


### PR DESCRIPTION
## Summary

Add `.claude/` and `.gemini-clipboard/` directories to `.gitignore` to prevent ephemeral user-local state from being tracked in version control.

- `.claude/`: Claude Code local configuration, hooks, commands, and settings
- `.gemini-clipboard/`: Temporary clipboard artifacts

## Test plan

- [x] Verified hidden directories are properly ignored
- [x] Confirmed no duplicate copies exist in the repository
- [x] Pre-commit checks passed

🤖 Generated with Claude Code