### PR TITLE
refactor: Full codebase audit - mypy deprecation, TYPE_CHECKING, progressive tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_no_return = true
 strict_equality = true
-strict_concatenate = true
+extra_checks = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/src/hestai_mcp/ai/providers/base.py
+++ b/src/hestai_mcp/ai/providers/base.py
@@ -4,8 +4,12 @@ SS-I2 Compliance: All provider calls must be async.
 """
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class CompletionRequest(BaseModel):
@@ -79,7 +83,3 @@ class BaseProvider(ABC):
             Various exceptions for connection errors, auth failures, etc.
         """
         pass
-
-
-# Import at end to avoid circular imports
-import httpx  # noqa: E402

--- a/tests/unit/integrations/test_progressive.py
+++ b/tests/unit/integrations/test_progressive.py
@@ -1,0 +1,122 @@
+"""Tests for progressive integration registry.
+
+Validates the data contract and structural integrity of INTEGRATION_POINTS
+without testing runtime import behavior (handled by CI preflight scripts).
+"""
+
+import pytest
+
+from hestai_mcp.integrations.progressive import (
+    INTEGRATION_POINTS,
+    IntegrationPointSpec,
+)
+
+
+class TestIntegrationPointSpec:
+    """Tests for IntegrationPointSpec dataclass structure."""
+
+    def test_integration_point_spec_is_frozen_dataclass(self) -> None:
+        """IntegrationPointSpec must be immutable (frozen=True)."""
+        spec = IntegrationPointSpec(
+            point_id="test",
+            stage="NOW",
+            reference_token="INTEGRATION_POINT::test",
+            implementation_import="hestai_mcp.test",
+            contract_test_glob="tests/contracts/test/test_*.py",
+            integration_test_glob="tests/integration/test/test_*.py",
+        )
+        with pytest.raises(AttributeError):
+            spec.point_id = "modified"  # type: ignore[misc]
+
+    def test_integration_point_spec_has_required_fields(self) -> None:
+        """IntegrationPointSpec must have all required fields."""
+        spec = IntegrationPointSpec(
+            point_id="test",
+            stage="NOW",
+            reference_token="INTEGRATION_POINT::test",
+            implementation_import="hestai_mcp.test",
+            contract_test_glob="tests/contracts/test/test_*.py",
+            integration_test_glob="tests/integration/test/test_*.py",
+        )
+        assert hasattr(spec, "point_id")
+        assert hasattr(spec, "stage")
+        assert hasattr(spec, "reference_token")
+        assert hasattr(spec, "implementation_import")
+        assert hasattr(spec, "contract_test_glob")
+        assert hasattr(spec, "integration_test_glob")
+
+
+class TestIntegrationPointsRegistry:
+    """Tests for INTEGRATION_POINTS registry data integrity."""
+
+    def test_registry_is_tuple(self) -> None:
+        """INTEGRATION_POINTS must be a tuple for immutability."""
+        assert isinstance(INTEGRATION_POINTS, tuple)
+
+    def test_registry_is_not_empty(self) -> None:
+        """INTEGRATION_POINTS must contain at least one entry."""
+        assert len(INTEGRATION_POINTS) > 0
+
+    def test_all_entries_are_integration_point_spec(self) -> None:
+        """Each entry must be an IntegrationPointSpec instance."""
+        for entry in INTEGRATION_POINTS:
+            assert isinstance(
+                entry, IntegrationPointSpec
+            ), f"Entry {entry} is not IntegrationPointSpec"
+
+    def test_stages_are_valid(self) -> None:
+        """Stages must be NOW, SOON, or LATER per ADR-0056."""
+        valid_stages = {"NOW", "SOON", "LATER"}
+        for entry in INTEGRATION_POINTS:
+            assert (
+                entry.stage in valid_stages
+            ), f"{entry.point_id} has invalid stage '{entry.stage}'"
+
+    def test_point_ids_are_unique(self) -> None:
+        """All point_id values must be unique."""
+        point_ids = [entry.point_id for entry in INTEGRATION_POINTS]
+        assert len(point_ids) == len(set(point_ids)), "Duplicate point_id found"
+
+    def test_reference_tokens_follow_convention(self) -> None:
+        """Reference tokens must follow INTEGRATION_POINT::{id} pattern."""
+        for entry in INTEGRATION_POINTS:
+            expected_token = f"INTEGRATION_POINT::{entry.point_id}"
+            assert (
+                entry.reference_token == expected_token
+            ), f"{entry.point_id} has non-standard reference_token"
+
+    def test_contract_test_globs_follow_convention(self) -> None:
+        """Contract test globs must follow tests/contracts/{id}/ pattern."""
+        for entry in INTEGRATION_POINTS:
+            assert entry.contract_test_glob.startswith(
+                "tests/contracts/"
+            ), f"{entry.point_id} contract_test_glob does not follow convention"
+            assert entry.contract_test_glob.endswith(
+                "/test_*.py"
+            ), f"{entry.point_id} contract_test_glob does not end with /test_*.py"
+
+    def test_integration_test_globs_follow_convention(self) -> None:
+        """Integration test globs must follow tests/integration/{id}/ pattern."""
+        for entry in INTEGRATION_POINTS:
+            assert entry.integration_test_glob.startswith(
+                "tests/integration/"
+            ), f"{entry.point_id} integration_test_glob does not follow convention"
+            assert entry.integration_test_glob.endswith(
+                "/test_*.py"
+            ), f"{entry.point_id} integration_test_glob does not end with /test_*.py"
+
+    def test_implementation_imports_are_valid_module_paths(self) -> None:
+        """Implementation imports must be valid Python module paths."""
+        for entry in INTEGRATION_POINTS:
+            if entry.implementation_import is not None:
+                # Check it looks like a valid module path
+                assert entry.implementation_import.startswith(
+                    "hestai_mcp"
+                ), f"{entry.point_id} implementation_import does not start with hestai_mcp"
+                # Check no invalid characters
+                assert (
+                    "/" not in entry.implementation_import
+                ), f"{entry.point_id} implementation_import contains /"
+                assert (
+                    "\\" not in entry.implementation_import
+                ), f"{entry.point_id} implementation_import contains \\"


### PR DESCRIPTION
## Summary

Full codebase audit that identified and fixed three code quality issues:

- **Fix deprecated mypy option**: Changed `strict_concatenate` to `extra_checks` in pyproject.toml to eliminate deprecation warning
- **Fix circular import pattern**: Replaced late `import httpx # noqa: E402` hack with proper `TYPE_CHECKING` pattern in base.py
- **Add tests for progressive.py**: Added 11 tests for data contract validation (0% → 100% coverage for this module)

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `strict_concatenate = true` → `extra_checks = true` |
| `src/hestai_mcp/ai/providers/base.py` | Late import → `TYPE_CHECKING` pattern |
| `tests/unit/integrations/test_progressive.py` | New file with 11 tests |

## Test Results

- **Tests**: 282 → 293 (+11 new tests)
- **Coverage**: 90% → 91%
- **mypy**: 0 errors (no deprecation warning)
- **ruff**: All checks passed
- **black**: All files formatted

## Audit Process

Used debate-hall multi-agent synthesis with three perspectives:
1. **Wind (Gemini/Ideator)**: Generated 6 creative improvement proposals
2. **Wall (Codex/Validator)**: Assessed each as VIABLE/RISKY/REJECT with evidence
3. **Door (Claude/Synthesizer)**: Created prioritized implementation plan

## Test plan

- [x] All 293 tests pass
- [x] mypy shows no errors or warnings
- [x] ruff linting passes
- [x] black formatting passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)