### PR TITLE
chore: migrate license from MIT to Apache 2.0 and add trademark notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Elevana Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+HestAI-MCP
+Copyright 2025 Elevana Ltd
+
+This product includes software developed at Elevana Ltd
+(https://elevana.com/).
+
+TRADEMARKS
+----------
+"Odyssean Anchor" is a registered trademark of Shaun Buswell.
+
+UK Trademark Registration: UK00004198373
+Class 42: Scientific and technological services
+Filing Date: 03 May 2025
+Registration Date: 01 August 2025
+
+The Apache License, Version 2.0 does not grant permission to use the
+trade names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of this NOTICE file.
+
+For trademark usage guidelines, see docs/trademarks.md.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **Model Context Protocol server implementing dual-layer context architecture for AI agent coordination**
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
@@ -141,4 +142,6 @@ Documentation placement is governed by rules in `hub/governance/rules/`:
 
 ## License
 
-MIT
+Apache License 2.0 - see [LICENSE](LICENSE) for details.
+
+"Odyssean Anchor" is a registered trademark of Shaun Buswell - see [docs/trademarks.md](docs/trademarks.md) for usage guidelines.

--- a/docs/odyssean-anchor-terminology.md
+++ b/docs/odyssean-anchor-terminology.md
@@ -1,5 +1,7 @@
 # Odyssean Anchor Terminology Guide
 
+> **Trademark Notice**: "Odyssean Anchor" is a registered trademark of Shaun Buswell (UK00004198373). See [trademarks.md](trademarks.md) for usage guidelines.
+
 **Status**: AUTHORITATIVE
 **Date**: 2026-01-01
 **Source**: debates/2026-01-01-identity-vs-binding-terminology.oct.md

--- a/docs/trademarks.md
+++ b/docs/trademarks.md
@@ -1,0 +1,52 @@
+# Trademark Policy
+
+## Odyssean Anchor
+
+"Odyssean Anchor" is a registered trademark of Shaun Buswell.
+
+| Detail | Value |
+|--------|-------|
+| **Trademark** | Odyssean Anchor |
+| **Registration Number** | UK00004198373 |
+| **Owner** | Shaun Buswell |
+| **Class** | 42 (Scientific and technological services) |
+| **Registration Date** | 01 August 2025 |
+| **Jurisdiction** | United Kingdom |
+
+## Permitted Uses
+
+You MAY use the "Odyssean Anchor" trademark:
+
+1. **Descriptive reference**: To accurately describe that your software implements or is compatible with the Odyssean Anchor binding protocol
+2. **Attribution**: In documentation, papers, or presentations that reference this project
+3. **Unmodified distribution**: When distributing unmodified copies of this software
+
+Examples of permitted use:
+- "Compatible with Odyssean Anchor"
+- "Implements the Odyssean Anchor binding protocol"
+- "Based on Odyssean Anchor technology"
+
+## Restricted Uses
+
+You MAY NOT use the "Odyssean Anchor" trademark:
+
+1. **As a product name**: For your own products or services
+2. **In domain names**: As part of a domain name for commercial purposes
+3. **Implying endorsement**: In any way that suggests endorsement or affiliation without explicit permission
+4. **Modified versions**: To name or promote modified versions of this software without clear differentiation
+
+## Requesting Permission
+
+For uses not covered above, contact the trademark owner to request permission.
+
+## Relationship to Apache License
+
+The Apache License, Version 2.0 under which this software is released explicitly states in Section 6:
+
+> "This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file."
+
+This trademark policy provides additional guidance on what constitutes "reasonable and customary use."
+
+## Other Trademarks
+
+All other trademarks mentioned in this project are the property of their respective owners.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@ description = "HestAI Context Management MCP Server - Dual-Layer Architecture"
 authors = [{name = "HestAI", email = "noreply@hestai.dev"}]
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary

- Migrate license from MIT to Apache License 2.0 (consistent with OCTAVE-MCP)
- Add trademark protection for "Odyssean Anchor" (UK00004198373)
- Establish clear IP ownership: Copyright (Elevana Ltd) and Trademark (Shaun Buswell)

## Changes

| File | Change |
|------|--------|
| `LICENSE` | Apache 2.0 full text (Copyright 2025 Elevana Ltd) |
| `NOTICE` | Copyright and trademark attribution |
| `docs/trademarks.md` | Odyssean Anchor trademark usage policy |
| `pyproject.toml` | Updated license field and classifiers |
| `README.md` | Added Apache badge and license section |
| `docs/odyssean-anchor-terminology.md` | Added trademark notice |

## Trademark Details

| Field | Value |
|-------|-------|
| Trademark | Odyssean Anchor |
| Registration | UK00004198373 |
| Owner | Shaun Buswell |
| Class | 42 (Scientific and technological services) |
| Registered | 01 August 2025 |

## Test plan

- [x] Pre-commit hooks pass (naming-standard, visibility-rules)
- [x] All quality gates pass (ruff, mypy)
- [x] Review LICENSE text matches Apache 2.0
- [x] Review trademark policy in docs/trademarks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)