### PR TITLE
docs(odyssean-anchor): align docs with two-layer terminology abstraction

### DIFF
--- a/.hestai/context/PROJECT-CONTEXT.oct.md
+++ b/.hestai/context/PROJECT-CONTEXT.oct.md
@@ -191,8 +191,8 @@ GOVERNANCE_ACTIONS_COMPLETED::[
 SCOPE::VERIFIED_ALIGNED::[
   ✅::persistent_memory_system[Layer_1_2_3_architecture],
   ✅::structural_governance_engine[read_only_Layer_1],
-  ✅::orchestra_conductor_ambient_awareness[ADR-0002_Orchestra_Map],
-  ✅::dual_layer_context_protocol[ADR-0001_proven]
+  ✅::orchestra_conductor_ambient_awareness[ADR-0034_Orchestra_Map],
+  ✅::dual_layer_context_protocol[ADR-0033_proven]
 ]
 
 ===END===

--- a/.hestai/research/odyssean-anchor-corpus.oct.md
+++ b/.hestai/research/odyssean-anchor-corpus.oct.md
@@ -6,6 +6,8 @@ META:
   EXTRACTED::"2026-01-02"
   PURPOSE::"Implementation patterns for odyssean_anchor MCP tool"
   EVIDENCE_BASE::"4 validated agent vectors + multi-model assessment + specification documents"
+  TERMINOLOGY::"See docs/odyssean-anchor-terminology.md for two-layer abstraction (Identity Composition vs Runtime Binding)"
+  LAYER::IDENTITY_COMPOSITION[design-time_patterns_for_agent_prompts]
 
 ## ERROR_TEMPLATES
 

--- a/.hestai/workflow/components/000-ODYSSEAN-ANCHOR-NORTH-STAR.md
+++ b/.hestai/workflow/components/000-ODYSSEAN-ANCHOR-NORTH-STAR.md
@@ -127,30 +127,58 @@ Any deviation requires formal amendment.
 
 ## SECTION 4: ARCHITECTURE SUMMARY
 
-### RAPH Vector Structure
+> **Terminology Note**: See docs/odyssean-anchor-terminology.md for the two-layer abstraction
+> (Identity Composition vs Runtime Binding).
+
+### Identity Composition (Design-Time): SHANK/ARM/FLUKE
+
+Used when DESIGNING agent constitutions:
 
 ```
-RAPH_VECTOR = {
-  SHANK: {               # Constitutional Identity
+ODYSSEAN ANCHOR (Agent Identity Architecture)
+├── SHANK    # WHO: Core identity (cognition + archetype)
+├── ARM      # WHERE/WHEN: Phase context (operational environment)
+└── FLUKE    # WHAT: Capabilities (skills, patterns, authority)
+```
+
+### Runtime Binding (Validation): RAPH Vector v4.0
+
+Used when VALIDATING agent binding via odyssean_anchor tool:
+
+```
+RAPH_VECTOR_v4.0 = {
+  BIND: {                # Identity Lock (encompasses SHANK + FLUKE.AUTHORITY)
     ROLE: string,        # Agent role name
     COGNITION: enum,     # ETHOS | LOGOS | PATHOS
-    ARCHETYPES: list,    # e.g., [ATLAS, ATHENA]
-    CONSTRAINTS: list    # Behavioral boundaries
+    ARCHETYPE: string,   # Primary archetype (e.g., HEPHAESTUS)
+    AUTHORITY: string    # RESPONSIBLE[scope] | DELEGATED[parent]
   },
-  ARM: {                 # Contextual Proof
+  ARM: {                 # Context Proof (SERVER-INJECTED, not agent-provided)
     PHASE: string,       # Current workflow phase
-    BRANCH: string,      # Git branch name
-    FILES: list,         # Key files read
-    BLOCKERS: list       # Known impediments
+    BRANCH: string,      # Git branch name + ahead/behind
+    FILES: int,          # Modified file count
+    FOCUS: string        # Session focus topic
   },
-  FLUKE: {               # Authority Gate
-    PARENT_SESSION: string,  # Parent session ID (if sub-agent)
-    DELEGATED_TASK: string,  # Task delegated by parent
-    SKILLS: list,            # Loaded skills
-    AUTHORITY_LEVEL: enum    # FULL | SCOPED | READONLY
+  TENSION: {             # Cognitive Proof (AGENT-GENERATED)
+    # L{N}::[constraint]<->CTX:{path}[state]->TRIGGER[action]
+    # Min count: quick=1, default=2, deep=3
+  },
+  COMMIT: {              # Falsifiable Contract
+    ARTIFACT: string,    # Concrete file path (not "response")
+    GATE: string         # Validation method
   }
 }
 ```
+
+### Relationship Mapping
+
+| Identity (Design) | Runtime (Binding) | Notes |
+|-------------------|-------------------|-------|
+| SHANK | BIND | BIND encompasses SHANK's identity |
+| ARM | ARM | Same semantic: contextual awareness |
+| FLUKE | BIND.AUTHORITY | FLUKE absorbed into BIND |
+| *(none)* | TENSION | Agent reasoning proof (new in v4.0) |
+| *(none)* | COMMIT | Falsifiable contract (new in v4.0) |
 
 ### Binding Flow
 


### PR DESCRIPTION
## Summary
Per docs/odyssean-anchor-terminology.md, there are two distinct layers:
1. **Identity Composition** (Design-Time): SHANK/ARM/FLUKE
2. **Runtime Binding** (Validation): RAPH Vector v4.0 (BIND/ARM/TENSION/COMMIT)

## Changes
- North Star: Updated Section 4 to show both layers with relationship mapping
- Corpus: Added TERMINOLOGY and LAYER metadata to clarify scope
- PROJECT-CONTEXT: Fixed remaining ADR-0001/0002 references to ADR-0033/0034

These documents were not in conflict - they describe different abstraction layers. This commit makes that distinction explicit.

## Test plan
- [x] Pre-commit hooks pass
- [x] OCTAVE validation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)