### PR TITLE
docs: rename /oa-load to /bind and add bind.md to hub library

### DIFF
--- a/.hestai/workflow/000-MCP-PRODUCT-NORTH-STAR-SUMMARY.oct.md
+++ b/.hestai/workflow/000-MCP-PRODUCT-NORTH-STAR-SUMMARY.oct.md
@@ -37,7 +37,7 @@ I4::FRESHNESS_VERIFICATION::[
 I5::ODYSSEAN_IDENTITY_BINDING::[
   PRINCIPLE::agents_must_undergo_structural_identity_verification_to_operate,
   WHY::prevents_generic_drift+enforces_role_constraints,
-  STATUS::PENDING[oa-load_tool]
+  STATUS::PENDING[bind_command]
 ]
 
 I6::UNIVERSAL_SCOPE::[

--- a/.hestai/workflow/components/000-ODYSSEAN-ANCHOR-NORTH-STAR.md
+++ b/.hestai/workflow/components/000-ODYSSEAN-ANCHOR-NORTH-STAR.md
@@ -42,7 +42,7 @@ Any deviation requires formal amendment.
 ### OA-I1: UNIFIED BINDING PATH
 **Requirement**: A single, universal binding protocol must be used for ALL agents (main, sub-agents, tools). "Special paths" for different agent types are prohibited.
 **Rationale**: Fragmentation in binding logic creates security holes where "dumb" agents bypass controls.
-**Validation**: `/oa-load` (or its API equivalent) is the exclusive entry point.
+**Validation**: `/bind` (or its API equivalent) is the exclusive entry point.
 
 ### OA-I2: STRUCTURAL VALIDATION (RAPH VECTOR)
 **Requirement**: Identity is not a string; it is a cryptographic structure (RAPH Vector) containing Role, Context Proof (ARM), and Authority (FLUKE). This structure must be machine-validated.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ Context must never be stale. We use a **Split-Artifact Hybrid** approach:
 Defined in [ADR-0036](adr/adr-0036-odyssean-anchor-binding.md).
 
 Agents must bind to the project with verified identity.
-*   **Unified Path**: Main agents and subagents use the exact same `/oa-load` ceremony.
+*   **Unified Path**: Main agents and subagents use the exact same `/bind` ceremony.
 *   **Structural Validation**: The `odyssean_anchor` MCP tool enforces a strict schema (RAPH Vector).
 *   **Self-Correction**: Agents must retry if validation fails (Max 2 attempts).
 

--- a/hub/library/commands/bind.md
+++ b/hub/library/commands/bind.md
@@ -1,0 +1,105 @@
+===BIND===
+// /bind {role} ["topic"] [--quick|--deep]
+// Odyssean Anchor binding v4.0 - MCP server-side validation
+// INSTALL: cp hub/library/commands/bind.md ~/.claude/commands/bind.md
+
+META:
+  VERSION::"4.0"
+  PATTERN::ODYSSEAN[identity_binding→server_validation→cognitive_proof]
+
+ALIASES::[ho→holistic-orchestrator,ce→critical-engineer,il→implementation-lead,ta→technical-architect,ea→error-architect,ca→completion-architect,wa→workspace-architect,ss→system-steward,rs→requirements-steward,td→task-decomposer,crs→code-review-specialist,tmg→test-methodology-guardian,tis→test-infrastructure-steward,ute→universal-test-engineer]
+
+FLAGS::[--quick→QUICK[1_tension],--deep→DEEP[3_tensions],DEFAULT→[2_tensions]]
+
+PARSE::[ROLE::first_token,TOPIC::quoted_or_null→"general",TIER::flag_or_DEFAULT]
+
+CRITICAL::[TodoWrite_FIRST,NO_PROSE_between_steps,TENSION_interprets_not_copies]
+
+---
+
+FLOW::
+  T0::TodoWrite(TODOS)→mark_complete
+  T1::CONSTITUTION→Read(".claude/agents/{role}.oct.md")→EXTRACT[COGNITION,ARCHETYPES,MUST[2],NEVER[2]]→SET_AUTHORITY[main→RESPONSIBLE|sub→DELEGATED]→EMIT
+  T2::CLOCK_IN→mcp__hestai__clock_in(role,focus,working_dir)→CAPTURE[SESSION_ID,CONTEXT_PATHS]→IF[FAIL]→STOP
+  T2b::ARM_CONTEXT→Read(project_context)→Bash(git_log+status+branch+ahead_behind)→EXTRACT[PHASE,BRANCH,FILES]→EMIT
+  T3::TENSION→GENERATE[L{N}::[constraint]↔CTX:{path}[state]→TRIGGER[action]]→MIN_COUNT_PER_TIER→mark_complete
+  T4::COMMIT→DECLARE[ARTIFACT::concrete_path,GATE::validation_method]→mark_complete
+  T5::ANCHOR→BUILD_VECTOR[BIND+TENSION+COMMIT]→mcp__hestai__odyssean_anchor(role,vector,session_id,working_dir,tier)→HANDLE_RESULT
+  T6::DASHBOARD→EMIT[VECTOR_BLOCK+DASHBOARD_BLOCK]→mark_complete
+
+TODOS::[
+  {content:"T0: TodoWrite",status:"in_progress",activeForm:"Sequencing"},
+  {content:"T1: Constitution",status:"pending",activeForm:"Identity"},
+  {content:"T2: clock_in + ARM",status:"pending",activeForm:"Context"},
+  {content:"T3: TENSION",status:"pending",activeForm:"Cognitive proof"},
+  {content:"T4: COMMIT",status:"pending",activeForm:"Contract"},
+  {content:"T5: Odyssean Anchor",status:"pending",activeForm:"MCP validation"},
+  {content:"T6: Dashboard",status:"pending",activeForm:"Summary"}
+]
+
+---
+
+T5_DETAIL::
+  BUILD::VECTOR_CANDIDATE::[
+    "## BIND",
+    "ROLE::{role}","COGNITION::{cognition}::{archetypes}","AUTHORITY::{authority}",
+    "## TENSION","{tensions_from_T3}",
+    "## COMMIT",
+    "ARTIFACT::{artifact}","GATE::{gate}"
+  ]
+  DO::mcp__hestai__odyssean_anchor(role:{ROLE},vector_candidate:{VECTOR},session_id:{SESSION_ID},working_dir:"{cwd}",tier:{TIER})
+  CAPTURE::[success,anchor,errors,guidance,terminal]
+  IF[!success∧!terminal]→EMIT(guidance)→RETRY::T3[max_2]
+  IF[!success∧terminal]→STOP::"BINDING FAILED"
+  IF[success]→CAPTURE::VALIDATED_ANCHOR
+
+---
+
+VECTOR_SCHEMA::v4.0
+  ===RAPH_VECTOR::v4.0===
+  ## BIND
+  ROLE::{name}
+  COGNITION::{type}::{archetype}
+  AUTHORITY::{RESPONSIBLE|DELEGATED[parent]}
+
+  ## ARM (MCP-INJECTED)
+  PHASE::{phase}
+  BRANCH::{name}[{ahead}↑{behind}↓]
+  FILES::{count}[{top}]
+  FOCUS::{topic}
+
+  ## TENSION (AGENT-GENERATED)
+  L{N}::[{constraint}]↔CTX:{path}[{state}]→TRIGGER[{action}]
+
+  ## COMMIT
+  ARTIFACT::{path}
+  GATE::{method}
+  ===END_RAPH_VECTOR===
+
+VALIDATION::[sections[BIND,ARM,TENSION,COMMIT],tension_count≥tier_min,L{N}_present,CTX_present,artifact_concrete]
+
+---
+
+DASHBOARD::
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  OK BIND COMPLETE
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ROLE:    {role} ({cognition}) | {archetypes}
+  SESSION: {session_id}
+  PROJECT: {phase} | {branch} ({ahead}↑{behind}↓)
+  FOCUS:   {focus}
+  ANCHOR:  VALIDATED
+  TIER:    {tier}
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ===END_BIND_SEQUENCE===
+
+---
+
+NEVER::[prose_between_steps,generic_tensions,COMMIT_as_"response",generate_ARM[server_does_this]]
+ALWAYS::[TodoWrite_first,mark_complete_per_step,TENSION_cites_L{N}+CTX,silent_between_steps]
+
+REFS::[ADR_0036,src/hestai_mcp/mcp/tools/odyssean_anchor.py,.hestai/workflow/components/000-ODYSSEAN-ANCHOR-NORTH-STAR.md]
+
+===END===
+
+**Execute bind for: $ARGUMENTS**


### PR DESCRIPTION
## Summary
- Updates all operational documentation references from `/oa-load` to `/bind` to reflect the canonical command name for Odyssean Anchor binding
- Adds `bind.md` command to `hub/library/commands/` for repository distribution
- Preserves debate file as historical documentation

## Changes
| File | Change |
|------|--------|
| `docs/ARCHITECTURE.md` | `/oa-load` → `/bind` in unified path reference |
| `.hestai/workflow/000-MCP-PRODUCT-NORTH-STAR-SUMMARY.oct.md` | `oa-load_tool` → `bind_command` in I5 status |
| `.hestai/workflow/components/000-ODYSSEAN-ANCHOR-NORTH-STAR.md` | `/oa-load` → `/bind` in OA-I1 validation |
| `hub/library/commands/bind.md` | New file - canonical command for repo distribution |

## Test plan
- [x] Verify all `/oa-load` references in operational docs are updated
- [x] Confirm `hub/library/commands/bind.md` matches user's `~/.claude/commands/bind.md`
- [x] Validate OCTAVE syntax passes pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)