### PR TITLE
docs: add Boris's verification insights and clarify rules loading

### DIFF
--- a/.hestai/reports/2026-01-03-global-claude-md-reduction.md
+++ b/.hestai/reports/2026-01-03-global-claude-md-reduction.md
@@ -58,8 +58,30 @@ All `.claude/rules/*.md` files consume tokens from session start.
 
 **Implication:** Keep rules concise. Current total: ~1.7k tokens (acceptable).
 
+## Boris's Key Insight: Verification
+
+From Boris's X post (2025): "Probably the most important thing to get great results
+out of Claude Code -- give Claude a way to verify its work. If Claude has that
+feedback loop, it will 2-3x the quality of the final result."
+
+HestAI alignment:
+- Quality gates (lint, typecheck, test) provide verification
+- TDD protocol enforces test-first verification
+- `odyssean_anchor` validates agent identity
+
+## Additional Boris Practices (from X post)
+
+| Practice | HestAI Status |
+|----------|---------------|
+| Plan mode first (shift+tab×2) | Supported via /design command |
+| Subagents for workflows | ✓ Task() with specialized agents |
+| PostToolUse hooks | ✓ SessionStart hooks implemented |
+| Shared `.claude/settings.json` | Not yet (local-first approach) |
+| Parallel sessions (5+ local) | ✓ Supported via worktrees |
+
 ## Related
 
-- Boris's recommendations: https://www.anthropic.com/engineering/claude-code-best-practices
+- Boris's X post: https://x.com/bcherny/status/2007179832300581177
+- Anthropic best practices: https://www.anthropic.com/engineering/claude-code-best-practices
 - I5 (Odyssean Identity Binding): Agents still undergo full binding ceremony
 - ADR-0007: Context delivered via .hestai/ structure


### PR DESCRIPTION
## Summary

Follow-up to PR #138 with additional findings from Boris's actual X post and user testing of `.claude/rules/` behavior.

## Changes

### 1. Clarified `.claude/rules/` loading behavior (`a5a9323`)

User testing confirmed rules are loaded at **startup**, not lazily:

| Behavior | Expected | Actual |
|----------|----------|--------|
| Rules discovery | Startup | ✓ Startup |
| Token consumption | On file match | ✗ Always loaded |
| `paths:` frontmatter | Lazy loading | Conditional **application** only |

**Implication:** Keep rules concise (~1.7k tokens currently acceptable).

### 2. Added Boris's X post insights (`c6a6970`)

From Boris's actual X post (not just official docs):

> "Probably the most important thing to get great results out of Claude Code -- give Claude a way to verify its work. If Claude has that feedback loop, it will 2-3x the quality of the final result."

Additional practices comparison:

| Practice | HestAI Status |
|----------|---------------|
| Plan mode first (shift+tab×2) | Supported via /design command |
| Subagents for workflows | ✓ Task() with specialized agents |
| PostToolUse hooks | ✓ SessionStart hooks implemented |
| Parallel sessions (5+ local) | ✓ Supported via worktrees |

## Source

- Boris's X post: https://x.com/bcherny/status/2007179832300581177

## Test plan

- [x] Verified `.claude/rules/` loading via `/memory` and `/context` commands
- [x] Confirmed Memory files token count unchanged after reading matching files

🤖 Generated with [Claude Code](https://claude.com/claude-code)