### PR TITLE
docs: fix bind.md path references to canonical hub/library/ location

### DIFF
--- a/.hestai/context/PROJECT-CHECKLIST.oct.md
+++ b/.hestai/context/PROJECT-CHECKLIST.oct.md
@@ -77,7 +77,7 @@ PHASE_2.5_ODYSSEAN_ANCHOR:
       TESTS::5_integration_tests
     bind_command:
       STATUS::DONE
-      LOCATION::docs/commands/bind.md
+      LOCATION::hub/library/commands/bind.md
       VERSION::v4.0
       USAGE::"Copy to ~/.claude/commands/bind.md"
 

--- a/.hestai/context/PROJECT-ROADMAP.oct.md
+++ b/.hestai/context/PROJECT-ROADMAP.oct.md
@@ -66,7 +66,7 @@ PHASES:
       ✅::odyssean_anchor_tool[949_lines+54_tests],
       ✅::gating_module[has_valid_anchor+22_tests],
       ✅::server_integration[5_integration_tests],
-      ✅::bind_command_v4.0[docs/commands/bind.md],
+      ✅::bind_command_v4.0[hub/library/commands/bind.md],
       ✅::RAPH_Vector_v4.0_schema[BIND+ARM+TENSION+COMMIT]
     ]
     ISSUE::#11
@@ -173,7 +173,7 @@ KEY_ACHIEVEMENTS_2026::[
     PR_#126::odyssean_anchor_tool[949_lines+54_tests],
     PR_#127-130::gating+integration+docs,
     QUALITY_GATES::[CRS_Codex_APPROVE,CE_Gemini_GO],
-    USAGE::"Copy docs/commands/bind.md to ~/.claude/commands/bind.md"
+    USAGE::"Copy hub/library/commands/bind.md to ~/.claude/commands/bind.md"
   ],
   2026-01-03::CONTEXT_FRESHNESS_UPDATE[I4_COMPLIANCE]::[
     PROJECT-CHECKLIST::updated_to_v0.5.0,

--- a/.hestai/reports/2026-01-02-bind-process-review.oct.md
+++ b/.hestai/reports/2026-01-02-bind-process-review.oct.md
@@ -31,7 +31,7 @@ BINDING_SUCCESS::first_attempt[no_retries_required]
 ### 1.1 Clear OCTAVE Command Structure
 
 ```
-LOCATION::docs/commands/bind.md
+LOCATION::hub/library/commands/bind.md
 EVIDENCE::[
   FLOW_CLARITY::T0→T1→T2→T2b→T3→T4→T5→T6[sequential_progression],
   TODOS_TEMPLATE::included_in_command[copy-paste_ready],

--- a/docs/adr/adr-0036-odyssean-anchor-binding.md
+++ b/docs/adr/adr-0036-odyssean-anchor-binding.md
@@ -150,7 +150,7 @@ The MCP tool enforces strict rules. If any rule fails, it returns a formatted er
 ## Migration Guide
 
 1.  **Agents**: Update `system-steward`, `implementation-lead`, etc., to use `odyssean_anchor` tool instead of `anchor_submit`.
-2.  **Commands**: Update `/bind` command to use `odyssean_anchor` MCP tool (see docs/commands/bind.md).
+2.  **Commands**: Update `/bind` command to use `odyssean_anchor` MCP tool (see hub/library/commands/bind.md).
 3.  **Subagents**: Update `Task()` prompt wrapper to instruct subagents to call `odyssean_anchor` first.
 
 ---


### PR DESCRIPTION
Update all references from deleted docs/commands/bind.md to the canonical location at hub/library/commands/bind.md per visibility-rules.

Files updated:
- PROJECT-CHECKLIST.oct.md
- PROJECT-ROADMAP.oct.md
- bind-process-review.oct.md
- adr-0036-odyssean-anchor-binding.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)