### PR TITLE
fix: use data.cwd for correct project path resolution in skill hook

### DIFF
--- a/.claude/hooks/skill-activation-prompt.ts
+++ b/.claude/hooks/skill-activation-prompt.ts
@@ -57,7 +57,7 @@ async function main(): Promise<void> {
     // 1. HESTAI_HUB_SKILLS_PATH (hub-level, set by setup-mcp.sh)
     // 2. HESTAI_SKILLS_PATH (explicit override or set by hook.sh)
     // 3. Local project hub/library/skills/ fallback
-    const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+    const projectDir = data.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
     const skillsBase =
       process.env.HESTAI_HUB_SKILLS_PATH ||
       process.env.HESTAI_SKILLS_PATH ||


### PR DESCRIPTION
## Problem

The skill activation hook was not working because it couldn't find skill-rules.json.

When the hook runs from `.claude/hooks` directory, `process.cwd()` returns the hooks directory instead of the project root. This created a doubled path:
- Expected: `/Volumes/HestAI-MCP/.claude/hooks/skill-rules.json`
- Actual: `/Volumes/HestAI-MCP/.claude/hooks/.claude/hooks/skill-rules.json`

## Solution

Use `data.cwd` from the hook input, which contains the actual project root directory. The hook input already provides this, but it wasn't being used.

## Changes

- Modified `skill-activation-prompt.ts` line 60 to use `data.cwd` as the first priority
- Maintains fallback to environment variables for flexibility

## Testing

Tested with:
```bash
echo '{"session_id":"test","cwd":"/Volumes/HestAI-MCP","prompt":"build execution"}' | npx tsx skill-activation-prompt.ts
```

Now correctly detects skills and outputs activation messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)