### PR TITLE
fix: Remove duplicate markdown fence and fix YAML quote

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/specs/odyssean-anchor-standalone.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/specs/odyssean-anchor-standalone.oct.md
@@ -229,7 +229,6 @@ anchor_lock(
   commit_template?: string    // Format guide
 }
 ```
-```
 
 #### `anchor_commit` (Step e)
 ```typescript
@@ -343,7 +342,7 @@ flukes:
   - id: "architecture-review"
     source: "file://flukes/arch-review.oct.md"
   - id: "tdd-workflow"
-    source: "file://flukes/tdd-workflow.oct.md
+    source: "file://flukes/tdd-workflow.oct.md"
 
 # Permission configuration for commit validation
 gates:


### PR DESCRIPTION
- Remove extra ``` fence after anchor_lock snippet that was causing malformed markdown rendering

- Add missing closing quote on tdd-workflow source path in profile YAML example