### PR TITLE
docs: Update bind command to use .hestai-sys/agents path

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/commands/bind.md
+++ b/src/hestai_mcp/_bundled_hub/library/commands/bind.md
@@ -19,7 +19,7 @@ CRITICAL::[TodoWrite_FIRST,NO_PROSE_between_steps,TENSION_interprets_not_copies]
 
 FLOW::
   T0::TodoWrite(TODOS)→mark_complete
-  T1::CONSTITUTION→Read(".claude/agents/{role}.oct.md")→EXTRACT[COGNITION,ARCHETYPES,MUST[2],NEVER[2]]→SET_AUTHORITY[main→RESPONSIBLE[scope]|sub→DELEGATED[parent_session]]→EMIT
+  T1::CONSTITUTION→Read(".hestai-sys/agents/{role}.oct.md")→EXTRACT[COGNITION,ARCHETYPES,MUST[2],NEVER[2]]→SET_AUTHORITY[main→RESPONSIBLE[scope]|sub→DELEGATED[parent_session]]→EMIT
   T2::CLOCK_IN→mcp__hestai__clock_in(role,focus,working_dir)→CAPTURE[SESSION_ID,CONTEXT_PATHS]→IF[FAIL]→STOP
   T2b::ARM_CONTEXT→Read(project_context)→Bash(git_log+status+branch+ahead_behind)→EXTRACT[PHASE,BRANCH,FILES]→EMIT
   T3::TENSION→GENERATE[L{N}::[constraint]⇌CTX:{path}[state]→TRIGGER[action]]→MIN_COUNT_PER_TIER→mark_complete


### PR DESCRIPTION
## Summary

- Updated agent constitution path in bind command from `.claude/agents` to `.hestai-sys/agents`
- Aligns with standardized agent directory structure

## Changes

- Modified `src/hestai_mcp/_bundled_hub/library/commands/bind.md` to reference `.hestai-sys/agents/{role}.oct.md` instead of `.claude/agents/{role}.oct.md`

## Test plan

- [ ] Verify bind command documentation is accurate
- [ ] Confirm path change aligns with actual agent directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)