### PR TITLE
fix: Ensure all 15 skills are v6 spec compliant

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/skills/documentation-placement/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/documentation-placement/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["documentation placement", "ADR placement", "phase artifact", "docume
 ---
 
 ===DOCUMENTATION_PLACEMENT===
-
 META:
   TYPE::SKILL
   VERSION::1.0
+  STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
   DOMAIN::HERMES[communication]⊕HESTIA[structure]
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-mode/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-mode/SKILL.md
@@ -6,8 +6,9 @@ allowed-tools: [Task, TodoWrite, AskUserQuestion, Read, Grep, Glob, Write, Edit,
 
 ===HO_MODE===
 META:
-  TYPE::LLM_PROFILE
+  TYPE::SKILL
   VERSION::"2.0"
+  STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
   TOKENS::"~120"
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-orchestrate/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-orchestrate/SKILL.md
@@ -6,8 +6,9 @@ allowed-tools: [Task, TodoWrite, AskUserQuestion, Read, Grep, Glob, Write, Edit,
 
 ===HO_ORCHESTRATE===
 META:
-  TYPE::LLM_PROFILE
+  TYPE::SKILL
   VERSION::"1.0"
+  STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
   TOKENS::"~200"
   EXTENDS::ho-mode

--- a/src/hestai_mcp/_bundled_hub/library/skills/mcp-tools/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/mcp-tools/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["MCP tool", "clock_in", "clock_out", "odyssean_anchor", "mcp server",
 ---
 
 ===MCP_TOOLS===
-
 META:
   TYPE::SKILL
   VERSION::"1.0"
+  STATUS::ACTIVE
   PURPOSE::"MCP tool implementation patterns for HestAI"
   DOMAIN::HEPHAESTUS[tool_crafting]⊕HERMES[communication]
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
@@ -5,12 +5,11 @@ allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["compress to octave", "semantic compression", "documentation refactoring", "octave compression", "compress documentation", "knowledge artifact", "semantic density", "OCTAVE format conversion"]
 ---
 
-# OCTAVE Compression Skill
-
 ===OCTAVE_COMPRESSION===
 META:
   TYPE::SKILL
   VERSION::"2.2"
+  STATUS::ACTIVE
   PURPOSE::"Workflow for transforming prose into semantic density"
   REQUIRES::octave-literacy
   TIER::LOSSLESS

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-literacy/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-literacy/SKILL.md
@@ -5,12 +5,11 @@ allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["octave format", "write octave", "octave syntax", "structured output", "OCTAVE basics", "OCTAVE literacy", "OCTAVE structure", "semantic format", "key::value", "OCTAVE notation"]
 ---
 
-# OCTAVE Literacy Skill
-
 ===OCTAVE_LITERACY===
 META:
   TYPE::SKILL
   VERSION::"1.1"
+  STATUS::ACTIVE
   PURPOSE::"Essential syntax and operators for basic OCTAVE competence"
   TIER::LOSSLESS
   SPEC_REFERENCE::octave-5-llm-core.oct.md

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-mastery/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-mastery/SKILL.md
@@ -5,12 +5,11 @@ allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["octave architecture", "agent design", "semantic pantheon", "advanced octave", "OCTAVE mastery", "holographic patterns", "archetypes", "high-density specifications", "system architecture", "OCTAVE patterns"]
 ---
 
-# OCTAVE Mastery Skill
-
 ===OCTAVE_MASTERY===
 META:
   TYPE::SKILL
   VERSION::"2.1"
+  STATUS::ACTIVE
   PURPOSE::"Expert-level OCTAVE application: Archetypes, Advanced Syntax, Strategy"
   REQUIRES::octave-literacy
   TIER::LOSSLESS

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-mythology/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-mythology/SKILL.md
@@ -5,12 +5,11 @@ allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["mythology", "archetype", "SISYPHEAN", "ICARIAN", "semantic compression", "evidence-based", "mythological domains", "OCTAVE mythology", "PROMETHEAN", "functional mythology", "compression patterns"]
 ---
 
-# OCTAVE Mythology Skill
-
 ===OCTAVE_MYTHOLOGY===
 META:
   TYPE::SKILL
   VERSION::"1.0"
+  STATUS::ACTIVE
   PURPOSE::"Functional mythological semantic compression for OCTAVE documents"
   PRINCIPLE::"Compression shorthand for LLM audiences, not ceremonial prose"
   EVIDENCE::[

--- a/src/hestai_mcp/_bundled_hub/library/skills/python-style/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/python-style/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["python style", "type hints", "docstrings", "python imports", "ruff",
 ---
 
 ===PYTHON_STYLE===
-
 META:
   TYPE::SKILL
   VERSION::"1.0"
+  STATUS::ACTIVE
   PURPOSE::"Python code style guidelines for HestAI MCP development"
   DOMAIN::HEPHAESTUS[craftsmanship]⊕ATHENA[precision]
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/stub-detection/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/stub-detection/SKILL.md
@@ -5,12 +5,13 @@ allowed-tools: ["Read", "Bash", "Grep", "Glob"]
 triggers: ["placeholder audit", "stub detection", "find stubs", "unimplemented features", "code audit", "incomplete implementation", "dead code", "hidden placeholders", "TODO", "FIXME", "NotImplementedError"]
 ---
 
-===STUB_DETECTION_PROTOCOL===
-
-VERSION::1.0.0
-STATUS::ACTIVE
-PURPOSE::Systematic_detection_of_placeholder_implementations
-ORIGIN::Derived_from_OCTAVE_MCP_audit_discovering_9_hidden_stubs
+===STUB_DETECTION===
+META:
+  TYPE::SKILL
+  VERSION::"1.0.0"
+  STATUS::ACTIVE
+  PURPOSE::Systematic_detection_of_placeholder_implementations
+  ORIGIN::Derived_from_OCTAVE_MCP_audit_discovering_9_hidden_stubs
 
 CORE_PRINCIPLE::"Not all placeholders leave obvious traces -> Silent failures most dangerous"
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/test-ci-pipeline/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/test-ci-pipeline/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["CI configuration", "github actions testing", "CI pipeline", "turbore
 ---
 
 ===TEST_CI_PIPELINE===
-
 META:
   TYPE::SKILL
   VERSION::1.0
+  STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
   DOMAIN::HEPHAESTUS[tool_crafting]⊕HERMES[coordination]
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/test-coverage/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/test-coverage/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["coverage analysis", "pytest coverage", "test gaps", "90% coverage", 
 ---
 
 ===TEST_COVERAGE===
-
 META:
   TYPE::SKILL
   VERSION::"1.0"
+  STATUS::ACTIVE
   PURPOSE::"Python pytest coverage analysis, gap identification, and TDD workflow for achieving 90%+ coverage"
   DOMAIN::ATHENA[quality]⊕ARTEMIS[precision_targeting]
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/test-infrastructure/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/test-infrastructure/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["vitest setup", "test configuration", "test infrastructure setup", "t
 ---
 
 ===TEST_INFRASTRUCTURE===
-
 META:
   TYPE::SKILL
   VERSION::1.0
+  STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
   DOMAIN::ATHENA[quality]⊕HEPHAESTUS[craftsmanship]
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/testing/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/testing/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["pytest", "test markers", "TDD", "test driven", "unit tests", "behavi
 ---
 
 ===TESTING===
-
 META:
   TYPE::SKILL
   VERSION::"1.0"
+  STATUS::ACTIVE
   PURPOSE::"Testing patterns and conventions for HestAI MCP"
   DOMAIN::ATHENA[quality]⊕HEPHAESTUS[craftsmanship]
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/vercel-preview/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/vercel-preview/SKILL.md
@@ -6,10 +6,10 @@ triggers: ["vercel preview", "preview deployment", "automation bypass", "protect
 ---
 
 ===VERCEL_PREVIEW===
-
 META:
   TYPE::SKILL
   VERSION::1.0
+  STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
   DOMAIN::HEPHAESTUS[tool_crafting]⊕HERMES[automation]
 


### PR DESCRIPTION
- Fix envelope names: stub-detection (===STUB_DETECTION_PROTOCOL=== → ===STUB_DETECTION===)
- Fix META TYPE fields: ho-mode, ho-orchestrate (LLM_PROFILE → SKILL)
- Add missing STATUS::ACTIVE field to all 15 skills (required per octave-6-llm-skills spec)
- Add proper META block structure to stub-detection (TYPE, VERSION, STATUS)

All skills now comply with octave-6-llm-skills.oct.md requirements:
- YAML frontmatter with name, description, allowed-tools, triggers, version
- ===SKILL_NAME=== envelope (no SKILL: prefix)
- META block with required: TYPE::SKILL, VERSION, STATUS
- Pure Octave body syntax (no markdown headers between YAML and envelope)