### PR TITLE
feat(hub): add YAML frontmatter to bundled agents

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/agents/code-review-specialist.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/code-review-specialist.oct.md
@@ -1,3 +1,8 @@
+---
+name: code-review-specialist
+description: Code quality enforcer responsible for security, architecture, and performance. Prevents validation theater through evidence-based review.
+---
+
 ===CODE_REVIEW_SPECIALIST===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/critical-engineer.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/critical-engineer.oct.md
@@ -1,3 +1,8 @@
+---
+name: critical-engineer
+description: Production readiness validator and domain accountability authority. Enforces reality through evidence-based validation.
+---
+
 ===CRITICAL_ENGINEER===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/design-architect.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/design-architect.oct.md
@@ -1,3 +1,8 @@
+---
+name: design-architect
+description: D3 blueprint architect. Transforms breakthrough concepts into implementation-ready specifications with stakeholder alignment.
+---
+
 ===DESIGN_ARCHITECT===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/edge-optimizer.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/edge-optimizer.oct.md
@@ -1,3 +1,8 @@
+---
+name: edge-optimizer
+description: Boundary exploration and hidden brilliance discovery. Finds breakthrough optimizations at solution edges.
+---
+
 ===EDGE_OPTIMIZER===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/ho-liaison.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/ho-liaison.oct.md
@@ -1,3 +1,8 @@
+---
+name: ho-liaison
+description: Advisory specialist providing operational analysis, codebase synthesis, and prophetic risk assessment to holistic-orchestrator.
+---
+
 ===HO_LIAISON===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
@@ -1,3 +1,8 @@
+---
+name: holistic-orchestrator
+description: Ultimate system orchestrator with constitutional authority.
+---
+
 ===HOLISTIC_ORCHESTRATOR===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/ideator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/ideator.oct.md
@@ -1,3 +1,8 @@
+---
+name: ideator
+description: Breakthrough innovation catalyst. Generates genius-level possibilities through cross-domain connection.
+---
+
 ===IDEATOR===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/implementation-lead.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/implementation-lead.oct.md
@@ -1,3 +1,8 @@
+---
+name: implementation-lead
+description: Build phase execution, task coordination, and code development. Manages systematic construction with architectural integrity.
+---
+
 ===IMPLEMENTATION_LEAD===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/principal-engineer.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/principal-engineer.oct.md
@@ -1,3 +1,8 @@
+---
+name: principal-engineer
+description: Architectural Sentinel responsible for long-term system health, stability, and scalability. Proactive guardian against systemic risks.
+---
+
 ===PRINCIPAL_ENGINEER===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/quality-observer.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/quality-observer.oct.md
@@ -1,3 +1,8 @@
+---
+name: quality-observer
+description: Quality observer and security integrated guardian. Ensures implementation excellence through systematic measurement and artifact verification.
+---
+
 ===QUALITY_OBSERVER===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/requirements-steward.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/requirements-steward.oct.md
@@ -1,3 +1,8 @@
+---
+name: requirements-steward
+description: Architectural conscience validating BOTH requirements alignment AND process adherence. Guards against drift in WHAT and HOW we build.
+---
+
 ===REQUIREMENTS_STEWARD===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/synthesizer.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/synthesizer.oct.md
@@ -1,3 +1,8 @@
+---
+name: synthesizer
+description: Breakthrough synthesis creator. Transforms tensions into third-way innovations.
+---
+
 ===SYNTHESIZER===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/system-steward.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/system-steward.oct.md
@@ -1,3 +1,8 @@
+---
+name: system-steward
+description: Meta-observer and system wisdom keeper. Preserves documentation, stewards git history, and recognizes emergent patterns.
+---
+
 ===SYSTEM_STEWARD===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/technical-architect.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/technical-architect.oct.md
@@ -1,3 +1,8 @@
+---
+name: technical-architect
+description: Technical architect for complex system design and architectural decisions. Creates scalable solutions through emergent synthesis.
+---
+
 ===TECHNICAL_ARCHITECT===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/test-infrastructure-steward.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/test-infrastructure-steward.oct.md
@@ -1,3 +1,8 @@
+---
+name: test-infrastructure-steward
+description: Test infrastructure authority with accountable ownership of CI pipelines, environments, and standards. Maintains reproducibility and prevents validation theater.
+---
+
 ===TEST_INFRASTRUCTURE_STEWARD===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/test-methodology-guardian.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/test-methodology-guardian.oct.md
@@ -1,3 +1,8 @@
+---
+name: test-methodology-guardian
+description: Test integrity guardian and TEST_INFRASTRUCTURE accountability authority. Prevents test manipulation and enforces blocking priority for integrity violations.
+---
+
 ===TEST_METHODOLOGY_GUARDIAN===
 META:
   TYPE::AGENT_DEFINITION

--- a/src/hestai_mcp/_bundled_hub/library/agents/validator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/validator.oct.md
@@ -1,3 +1,8 @@
+---
+name: validator
+description: Unflinching reality enforcer. Delivers cold truth through evidence-based constraint validation.
+---
+
 ===VALIDATOR===
 META:
   TYPE::AGENT_DEFINITION


### PR DESCRIPTION
Adds YAML frontmatter (name/description) to the canonical hub agent files under `src/hestai_mcp/_bundled_hub/library/agents/*.oct.md`.

Why:
- Align hub agents with `~/.claude/agents` expectations (frontmatter present)
- Keeps OCTAVE agent body unchanged (validator strips frontmatter)

Notes:
- Local `~/.claude/agents` copies were updated after this change (not part of repo).