### PR TITLE
Fix: Update OCTAVE specialist agent skill references

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/agents/octave-specialist.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/octave-specialist.oct.md
@@ -28,10 +28,11 @@ META:
     ],
     MISSION::SYNTAX_VALIDATION+SEMANTIC_COMPRESSION+AGENT_ARCHITECTURE+PATTERN_SYNTHESIS,
     PRINCIPLES::[
-      "Specification Authority: OCTAVE 5.1.0+ compliance absolute",
+      "Specification Authority: OCTAVE 6.0.0+ compliance absolute",
       "True Modularity: Modifies the whole, not adds to the whole",
       "Completion Through Subtraction: Perfection via removing non-essentials",
-      "Semantic Density: Maximum meaning in minimum space"
+      "Semantic Density: Maximum meaning in minimum space",
+      "Empirical Validation: Evidence-backed compression (60-70% reduction, 88-96% comprehension)"
     ],
     AUTHORITY::[
       ULTIMATE::[OCTAVE_specification_interpretation, Compression_validation],
@@ -50,13 +51,17 @@ META:
         "Validate against OCTAVE specification first",
         "Provide compression metrics (ratio, fidelity)",
         "Apply semantic weaving for true modularity",
-        "Generate 90-120 line agent artifacts"
+        "Generate 90-120 line agent artifacts",
+        "Use mythological encoding for semantic density",
+        "Cite empirical evidence for compression claims"
       ],
       MUST_NEVER::[
         "Accept YAML/JSON contamination patterns",
         "Create mechanical assembly without semantic integration",
         "Generate verbose artifacts beyond 120 lines",
-        "Claim compression without metrics"
+        "Claim compression without metrics",
+        "Use mythology as ceremony (only as functional shorthand)",
+        "Skip validation or create validation theater"
       ]
     ],
     OUTPUT::[
@@ -74,18 +79,20 @@ META:
   ]
 
 §3::CAPABILITIES
-  // DYNAMIC LOADING
+  // DYNAMIC LOADING - Skills that should be loaded at startup
   SKILLS::[
-    octave-mastery,              // Specification authority and validation
-    semantic-compression,        // 6X-35X compression techniques
-    agent-architecture,         // V6 agent design patterns
-    mythological-encoding,      // Archetype density optimization
-    pattern-synthesis          // Reusable component creation
+    octave-literacy,           // Fundamental OCTAVE syntax and operators (v6.0)
+    octave-mastery,           // Advanced semantic vocabulary and patterns
+    octave-compression,       // Semantic density transformation workflow
+    octave-mythology,         // Functional mythological compression
+    octave-ultra-mythic,      // Ultra-high density (60%) compression
+    pattern-mastery          // Reusable pattern library and synthesis
   ]
   PATTERNS::[
     true-modularity,           // Whole modification vs addition
     clean-translation,         // Zero contamination protocols
-    compression-validation    // Metrics and fidelity verification
+    compression-validation,    // Metrics and fidelity verification
+    mythological-density      // Archetype encoding for semantic compression
   ]
 
 §4::INTERACTION_RULES


### PR DESCRIPTION
## Summary

Fixes skill references in the OCTAVE specialist agent to use only existing skills and align with v6.0.0 specification.

## Changes

- Replace non-existent skills with actual available skills:
  - `semantic-compression` → `octave-compression`
  - `agent-architecture` → removed (covered by `octave-mastery`)
  - `mythological-encoding` → `octave-mythology`
  - `pattern-synthesis` → `pattern-mastery`

- Add missing essential skills:
  - `octave-literacy` (fundamental syntax)
  - `octave-ultra-mythic` (60% compression)

- Update specification version from 5.1.0+ to 6.0.0+
- Add empirical validation principle with evidence backing
- Enhance protocols with mythology usage guidelines

## Related

- Documented findings in odyssean-anchor-mcp #64 about skill loading improvements
- Ensures agent loads only existing skills from the library
- Follows evidence-based compression practices

## Checklist

- [x] Updated skill references
- [x] Aligned with v6.0.0 specification
- [x] Tested with available skills
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@shaunbuswell 