### PR TITLE
chore: Update octave-mcp dependency to v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "keyring>=24.0.0",
     "pyyaml>=6.0",
-    "octave-mcp>=0.6.1,<1.0.0",  # Official OCTAVE parser library
+    "octave-mcp>=1.0.0",  # Official OCTAVE parser with GBNF export support
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "keyring", specifier = ">=24.0.0" },
     { name = "mcp", specifier = ">=0.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "octave-mcp", specifier = ">=0.6.1,<1.0.0" },
+    { name = "octave-mcp", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -681,7 +681,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "0.6.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -690,9 +690,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/2e/37614ad1e37fd8d6f635b8d150b6cfd65b5e82cfd7413c767a0136358929/octave_mcp-0.6.1.tar.gz", hash = "sha256:23c264862601d9f47c3e62988057836d5092c337e1417726ebd55e15ce65e862", size = 151752, upload-time = "2026-01-12T14:56:02.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/98/c570de58c99b800425f300beb3422ce37137a18de5f52a031e30029b93c9/octave_mcp-1.0.0.tar.gz", hash = "sha256:cdc3d8613605aa3a48f084ce6ea19ff8ca9721e925f9b985c90b00110ea46fdf", size = 188904, upload-time = "2026-01-30T15:48:59.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/a0/b8476d6f0070e69dd938d5b35f79eb0bc83545d783095e91781096354a8b/octave_mcp-0.6.1-py3-none-any.whl", hash = "sha256:29bffa90e2d2c668cc04333cd19d5039809d38647649477789df86d2291673f5", size = 171978, upload-time = "2026-01-12T14:56:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e1/6ed7de04eae5818ec3e94a32d68286031d46e6d829bc1d6798665f223140/octave_mcp-1.0.0-py3-none-any.whl", hash = "sha256:d15cb73e0bde4d59fe3f52ca36e41ae0ab130018b66b076470c838ce865226e7", size = 211617, upload-time = "2026-01-30T15:48:57.528Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update octave-mcp from `>=0.6.1,<1.0.0` to `>=1.0.0`
- All 603 tests pass with the updated dependency
- Quality gates (ruff, black, mypy) all pass

## New Capabilities Available in v1.0.0

### GBNF Compiler
Compiles OCTAVE schemas and constraints to llama.cpp GBNF format for constrained text generation. This allows forcing AI outputs to match specific formats.

### Integrations Module
New helpers for LLM backends:
- `llama_cpp.py` - llama.cpp GBNF formatting and validation
- `vllm.py` - vLLM integration helpers
- `outlines.py` - Outlines JSON Schema export

### MCP Eject Tool Enhancement
New `gbnf` output format option for exporting llama.cpp grammars via the eject tool.

### META.CONTRACT Support (Issue #191)
v6 self-describing documents with embedded validation rules. Documents can now carry their own validation constraints in the META block.

## Test plan
- [x] All 603 tests pass
- [x] ruff check passes
- [x] black --check passes  
- [x] mypy src passes
- [x] Coverage at 91%

🤖 Generated with [Claude Code](https://claude.com/claude-code)