### PR TITLE
Fix: Remove non-existent pattern references from octave-specialist agent

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/agents/octave-specialist.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/octave-specialist.oct.md
@@ -88,12 +88,7 @@ META:
     octave-ultra-mythic,      // Ultra-high density (60%) compression
     pattern-mastery          // Reusable pattern library and synthesis
   ]
-  PATTERNS::[
-    true-modularity,           // Whole modification vs addition
-    clean-translation,         // Zero contamination protocols
-    compression-validation,    // Metrics and fidelity verification
-    mythological-density      // Archetype encoding for semantic compression
-  ]
+  PATTERNS::[]  // No external patterns - behaviors defined in §2::BEHAVIOR
 
 §4::INTERACTION_RULES
   // HOLOGRAPHIC CONTRACT


### PR DESCRIPTION
## Summary

Fixes follow-up issue from agent review: removes references to non-existent pattern library files from the OCTAVE specialist agent definition.

## Problem

The agent file listed pattern library references that don't exist:
- `true-modularity`
- `clean-translation`
- `compression-validation`
- `mythological-density`

These are behavioral concepts, not actual pattern library files. The agent was flagged during review for referencing non-existent files.

## Solution

- Removed all pattern library references
- Clarified that behaviors are defined in §2::BEHAVIOR
- Agent now only references actual existing skills and files

## Related

- Addresses review feedback on PR #199
- Validates that agent only references existing library files
- Ensures agent definition matches available resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@shaunbuswell 