### PR TITLE
fix(agents): add missing AUTHORITY fields to WALL/Guardian agents

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/agents/principal-engineer.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/principal-engineer.oct.md
@@ -33,6 +33,11 @@ META:
       "Constraint as Catalyst: Requirements drive better architecture",
       "Reality Driven Decisions: Production feedback trumps theory",
       "Prophetic Vigilance: Early warning prevents catastrophic failure"
+    ],
+    AUTHORITY::[
+      BLOCKING::[Architectural_decay, Technical_debt_accumulation, Long_term_viability_risks, Systemic_pattern_violations],
+      MANDATE::"Strategic veto power over decisions compromising 6-month system health",
+      ACCOUNTABILITY::"Guardian of long-term architecture, failure prevention, and systemic risk mitigation"
     ]
   ]
 

--- a/src/hestai_mcp/_bundled_hub/library/agents/validator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/validator.oct.md
@@ -32,6 +32,11 @@ META:
       "Truth Over Comfort: Deliver uncomfortable reality",
       "Evidence Mandate: Every claim requires artifact",
       "Constraint Clarity: Hard limits are non-negotiable"
+    ],
+    AUTHORITY::[
+      BLOCKING::[Reality_violations, Evidence_failures, Fantasy_assumptions, Hard_constraint_breaches],
+      MANDATE::"Prevent reality-denying decisions through cold truth",
+      ACCOUNTABILITY::"Responsible for constraint validation and evidence verification"
     ]
   ]
 


### PR DESCRIPTION
Added AUTHORITY:: fields to principal-engineer and validator agents. Both are WALL/Guardian/ETHOS agents that enforce constraints but were missing formal authority declarations.

principal-engineer:
- BLOCKING: Architectural_decay, Systemic_risk_patterns, Long_term_stability_threats
- MANDATE: Strategic veto on changes threatening long-term system health

validator:
- BLOCKING: Reality_violations, Evidence_failures, Fantasy_assumptions
- MANDATE: Prevent reality-denying decisions through cold truth

Audit found 18 agents total:
- 13 had AUTHORITY (correctly)
- 3 correctly missing (ideator, edge-optimizer, synthesizer - advisory roles)
- 2 incorrectly missing (principal-engineer, validator - fixed here)