### PR TITLE
feat(ci): Governance Socket pattern for review-gate distribution

### DIFF
--- a/.github/workflows/review-gate-caller.yml.template
+++ b/.github/workflows/review-gate-caller.yml.template
@@ -18,6 +18,15 @@ on:
 
 jobs:
   check-review:
+    # Only invoke for PR events or comments on PRs (not plain issue comments)
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request
     uses: elevanaltd/HestAI-MCP/.github/workflows/review-gate.yml@v1
+    # Caller must declare permissions explicitly - the reusable workflow
+    # cannot elevate beyond what the caller allows. Without these, orgs
+    # with restrictive default permissions will block PR commenting.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -52,7 +52,17 @@ jobs:
             echo "script_path=.review-gate-tools/scripts/validate_review.py" >> $GITHUB_OUTPUT
           fi
 
+      # --- Checkout the target repo (caller or self) ---
+      # NOTE: This MUST come before the tools checkout below, because
+      # actions/checkout with clean:true (default) runs git clean -ffdx
+      # which would delete any previously checked-out untracked directories.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       # --- Cross-repo: fetch review-gate tooling from HestAI-MCP ---
+      # Checked out into a subdirectory of the already-checked-out repo.
+      # Must come AFTER the target repo checkout to survive git clean.
       - name: Checkout review-gate tooling
         if: steps.context.outputs.mode == 'remote'
         uses: actions/checkout@v4
@@ -61,11 +71,6 @@ jobs:
           path: .review-gate-tools
           sparse-checkout: scripts/validate_review.py
           sparse-checkout-cone-mode: false
-
-      # --- Checkout the target repo (caller or self) ---
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary

- Transforms `review-gate.yml` into a reusable workflow supporting both local and cross-repo execution via `workflow_call`
- Adds dual-checkout strategy: sparse-checkout of HestAI-MCP (for `validate_review.py`) + checkout of calling repo's code
- Adds thin caller template (`review-gate-caller.yml.template`) for repos outside the org
- Org-level ruleset configured separately for repos within `elevanaltd`

## Architecture: The Governance Socket

| Layer | Location | Contains |
|-------|----------|----------|
| **System (Authority)** | `elevanaltd/HestAI-MCP` | Reusable workflow + `validate_review.py` |
| **Consumer (Subscriber)** | Org ruleset OR caller template | Pointer only, zero governance logic |

## Key Design Decisions

- **Checkout ordering**: Target repo first, tools sparse-checkout second (prevents `git clean -ffdx` from deleting tools dir)
- **PR number resolution**: Three-tier fallback (workflow_call input → pull_request event → issue_comment URL parsing)
- **Shell injection prevention**: `base.ref` moved to env block, not inline `${{ }}`
- **No `secrets: inherit`**: Caller template uses only `github.token` (automatic)
- **Caller permissions**: Explicit `contents:read`, `pull-requests:write`, `issues:write`

## Review History

- Debate: `2026-02-09-review-gate-v2` (Wind/Wall/Door synthesis → "Governance Socket")
- CRS (Gemini): APPROVED
- CE (Codex): APPROVED after 2 rework cycles (caught checkout ordering bug, caller permissions gap, issue_comment scoping)

## Test plan

- [ ] Review-gate runs correctly on this PR (local mode)
- [ ] Verify org ruleset enforces review-gate on consuming repos
- [ ] Test caller template from a non-HestAI-MCP repo (external mode)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)