### PR TITLE
feat(ci): scan PR description for approvals in addition to comments (#213)

### DIFF
--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -114,9 +114,12 @@ def _matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
       - 'CRS  APPROVED' (extra whitespace)
       - 'IL SELF-REVIEWED:' and 'IL (Claude): SELF-REVIEWED:'
 
-    The regex pattern is: {prefix}\\s*(\\([^)]*\\)\\s*:?\\s*)?{keyword}
+    Uses a word boundary (\\b) after the keyword to prevent substring false
+    positives (e.g., 'APPROVEDLY' must not match as 'APPROVED').
+
+    The regex pattern is: {prefix}\\s*(\\([^)]*\\)\\s*:?\\s*)?{keyword}\\b
     """
-    pattern = rf"{re.escape(prefix)}\s*(\([^)]*\)\s*:?\s*)?{re.escape(keyword)}"
+    pattern = rf"{re.escape(prefix)}\s*(\([^)]*\)\s*:?\s*)?{re.escape(keyword)}\b"
     return bool(re.search(pattern, text))
 
 


### PR DESCRIPTION
## Summary

Extends the review gate validation script to scan PR description body in addition to comments for approval patterns. Adds flexible regex matching to support both exact formats (`CRS APPROVED:`) and parenthetical model formats (`CRS (Gemini): APPROVED`).

## Problem

The review gate validation script (`scripts/validate_review.py`) only scanned PR comments for approval patterns. In practice, CRS and CE reviews are often conducted before the PR is created, with the approval summary included in the PR description. This meant the gate always failed on first run, requiring approvals to be re-posted as separate comments.

## Solution

**Commit 1: Core Feature (`8193a50`)**
- Extended `check_pr_comments()` to fetch both `comments,body` from `gh pr view`
- Added `_matches_approval_pattern()` helper using flexible regex to match:
  - `CRS APPROVED:` (original exact format)
  - `CRS (Gemini): APPROVED` (parenthetical model annotation)
  - `CRS  APPROVED` (extra whitespace)
  - `IL (Claude): SELF-REVIEWED:` (parenthetical self-review)
- Added `_has_approval()` helper to check approval patterns across text list
- Added 10 new tests covering PR body scanning and flexible pattern matching

**Commit 2: CRS/CE Finding Fix (`32c4f39`)**
- Added `\b` word boundary after keyword in regex to prevent substring false positives
- Prevents suffix matches like `APPROVEDLY` incorrectly matching as `APPROVED`
- Added 8 regression tests for substring false positive prevention

## Changes

- **`scripts/validate_review.py`** — Extended approval checking logic with flexible regex (78 lines added/changed)
- **`tests/test_validate_review.py`** — Added 18 new tests across 3 test classes (303 lines added)

## Quality Gates

| Gate | Status |
|------|--------|
| ruff check | ✓ All checks passed |
| black --check | ✓ All files formatted |
| mypy src | ✓ 0 issues in 43 files |
| pytest | ✓ 621 passed, 91% coverage |

## Reviews

**CRS (Claude):** APPROVED — 0 critical issues, 1 MEDIUM advisory (substring false positive) addressed in commit 2

**CE (Codex):** APPROVED — advisory findings only, no blocking issues

## Test Plan

- [x] Existing approval formats still work (`CRS APPROVED:`, `CE APPROVED:`, `IL SELF-REVIEWED:`)
- [x] Parenthetical model formats work (`CRS (Gemini): APPROVED`, `CE (Claude): APPROVED`)
- [x] Approvals in PR body are recognized
- [x] Approvals split between body and comments work (e.g., CRS in body, CE in comment)
- [x] Substring false positives prevented (`APPROVEDLY`, `DISAPPROVED` do not match)
- [x] Word boundary behavior validated (approval at end of line still matches)
- [x] All 621 project tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)