### PR TITLE
feat(hub): add subagent-rules skill and register in HO agent

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
@@ -81,7 +81,8 @@ META:
     system-orchestration,
     constitutional-enforcement,
     ho-mode,  // Critical lane discipline - prevents implementation drift
-    ho-orchestrate  // Essential for comprehensive system orchestration
+    ho-orchestrate,  // Essential for comprehensive system orchestration
+    subagent-rules  // Delegation patterns for Task() via oa-router
   ]
   PATTERNS::[
     mip-orchestration,          // Minimal Intervention for orchestration overhead

--- a/src/hestai_mcp/_bundled_hub/library/skills/subagent-rules/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/subagent-rules/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: subagent-rules
+description: Proper delegation patterns for Task() invocations with governance context injection
+allowed-tools: ["Task", "Read", "Bash"]
+---
+
+# Subagent Delegation Rules
+
+§1::ROUTING_RULE
+
+ALL agent delegation MUST use `oa-router` as the subagent_type.
+Do NOT call role-specific agents directly (e.g., technical-architect, implementation-lead).
+The oa-router runs the anchor ceremony which provides identity, governance, and context.
+
+PATTERN::[
+  ALWAYS::Task(subagent_type:"oa-router", prompt:"role: {role}\ntier: {tier}\ntopic: {topic}\n\n## YOUR TASK\n{task}")
+  NEVER::Task(subagent_type:"{role-name}", prompt:"{task}")
+]
+
+§2::TEMPLATE
+
+```
+Task({
+  subagent_type: "oa-router",
+  description: "{brief description}",
+  prompt: `
+role: {role}
+tier: {tier|default}
+topic: {context for ARM computation}
+
+## YOUR TASK
+{detailed task description}
+
+## SUCCESS CRITERIA
+{what done looks like}
+  `
+})
+```
+
+§3::TIER_SELECTION
+
+| Tier | Use When | Tensions |
+|------|----------|----------|
+| micro | Trivial read-only tasks | 0 (bypass) |
+| quick | Fast iteration, single constraint | 1 |
+| default | Standard work | 2 |
+| deep | Critical decisions, production impact | 3 |
+
+§4::EXAMPLES
+
+**Implementation work:**
+```
+Task({
+  subagent_type: "oa-router",
+  description: "Implement JWT auth with TDD",
+  prompt: `
+role: implementation-lead
+tier: default
+topic: JWT authentication implementation
+
+## YOUR TASK
+Implement JWT-based auth service with bcrypt hashing and refresh tokens.
+
+## SUCCESS CRITERIA
+- TDD discipline: RED->GREEN->REFACTOR
+- All quality gates passing
+  `
+})
+```
+
+**Architectural review:**
+```
+Task({
+  subagent_type: "oa-router",
+  description: "Review auth module architecture",
+  prompt: `
+role: technical-architect
+tier: quick
+topic: authentication module design review
+
+## YOUR TASK
+Review src/auth/ for architectural soundness. Apply MIP pattern.
+
+## SUCCESS CRITERIA
+- ASSESSMENT and SYNTHESIS provided
+- Actionable recommendations
+  `
+})
+```
+
+**Error resolution:**
+```
+Task({
+  subagent_type: "oa-router",
+  description: "Resolve CI type errors",
+  prompt: `
+role: error-architect
+tier: quick
+topic: CI pipeline type error cascade
+
+## YOUR TASK
+47 TypeScript errors across 12 files. Apply ERROR TRIAGE LOOP.
+
+## SUCCESS CRITERIA
+- Root cause identified
+- CI pipeline green
+  `
+})
+```
+
+§5::WHY_OA_ROUTER
+
+The anchor ceremony provides everything the old manual injection did:
+- Identity (ROLE, COGNITION, AUTHORITY) - from agent file
+- Governance (Constitution, North Star, I1-I7) - from SEA proof
+- Context (phase, branch, git state) - from ARM computation
+- Capabilities (skill/pattern content) - loaded during FLUKES
+- Enforcement (permit for tool gating) - from COMMIT
+
+Manual injection of TRACED, DOD, authority matrices is no longer needed.
+The anchor handles it.
+
+§6::ANTI_PATTERNS
+
+WRONG::Task(subagent_type:"technical-architect", prompt:"review this")
+  // Static injection duplicates what anchor would provide
+
+WRONG::Task(subagent_type:"oa-router", prompt:"review the auth module")
+  // Missing role - oa-router cannot bind without knowing what to become
+
+RIGHT::Task(subagent_type:"oa-router", prompt:"role: technical-architect\ntopic: auth review\n\n## YOUR TASK\nReview auth module")


### PR DESCRIPTION
## Summary
- Add `subagent-rules` skill to bundled hub at `src/hestai_mcp/_bundled_hub/library/skills/subagent-rules/SKILL.md`, providing Task() delegation patterns via oa-router with tier selection, templates, examples, and anti-patterns
- Register `subagent-rules` in holistic-orchestrator agent §3::CAPABILITIES for automatic loading during anchor ceremonies
- Reviewed anchor skill loading for streamlining — current 7-skill + 2-pattern set is lean; tier system (quick/micro) is the correct lever for reducing ceremony overhead rather than skill removal

## Test plan
- [ ] Verify skill file is discoverable by anchor ceremony (ARM stage loads skills from §3::CAPABILITIES)
- [ ] Confirm HO agent prompt includes `subagent-rules` in skill list
- [ ] Validate existing tests still pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)