### PR TITLE
docs: use explicit .venv/bin/python in CLAUDE.md quick commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,21 +4,24 @@ Python MCP server providing context management tools for Claude Code.
 
 ## Quick Commands
 
+**Always use `.venv/bin/python` — the system `python` does not have project packages.**
+The `.venv` is created by the session startup hook (`uv sync --all-extras`).
+
 ```bash
 # Quality gates (run before committing)
-python -m ruff check src tests scripts
-python -m black --check src tests scripts
-python -m mypy src
-python -m pytest
+.venv/bin/python -m ruff check src tests scripts
+.venv/bin/python -m black --check src tests scripts
+.venv/bin/python -m mypy src
+.venv/bin/python -m pytest
 
 # Fix formatting
-python -m black src tests scripts
-python -m ruff check --fix src tests scripts
+.venv/bin/python -m black src tests scripts
+.venv/bin/python -m ruff check --fix src tests scripts
 
 # Run specific test markers
-python -m pytest -m smoke       # Fast sanity checks
-python -m pytest -m behavior    # Behavioral tests (NOW)
-python -m pytest -m contract    # Contract tests (SOON)
+.venv/bin/python -m pytest -m smoke       # Fast sanity checks
+.venv/bin/python -m pytest -m behavior    # Behavioral tests (NOW)
+.venv/bin/python -m pytest -m contract    # Contract tests (SOON)
 ```
 
 ## Core Files


### PR DESCRIPTION
## Summary

- Replaces bare `python -m ...` commands in CLAUDE.md with `.venv/bin/python -m ...`
- Adds an explanatory note warning agents that system `python` lacks project packages
- Adds a session startup hook message reminding agents to use the venv path

## Root Cause

Agents were reporting "worktree environment isn't set up with the venv" because:

1. The `.venv` **is** created correctly by the session startup hook via `uv`
2. Hooks run in subshells — `source activate` cannot propagate to Claude Code's agent shell
3. `~/.zshrc` aliases `python=python3` → `/opt/homebrew/opt/python@3.13`, which has no project packages
4. CLAUDE.md instructed `python -m pytest`, causing agents to use the wrong interpreter

## Test plan

- [ ] Start a new Claude Code session in this worktree and confirm hook emits the `.venv/bin/python` reminder
- [ ] Confirm agents use `.venv/bin/python -m pytest` successfully
- [ ] Verify quality gates pass: `.venv/bin/python -m ruff check src tests scripts && .venv/bin/python -m mypy src && .venv/bin/python -m pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)