### PR TITLE
feat: Holographic Constitution layer 3 — session boundary integrity (#235)

### DIFF
--- a/src/hestai_mcp/modules/tools/shared/governance_integrity.py
+++ b/src/hestai_mcp/modules/tools/shared/governance_integrity.py
@@ -31,7 +31,15 @@ def apply_readonly_permissions(governance_dir: Path) -> None:
 
     Args:
         governance_dir: Path to .hestai-sys/ directory
+
+    Raises:
+        ValueError: If governance_dir is itself a symlink (root-level substitution attack)
     """
+    if governance_dir.is_symlink():
+        raise ValueError(
+            f"governance_dir is a symlink — potential root-level substitution attack: "
+            f"{governance_dir}"
+        )
     if not governance_dir.exists():
         return
 
@@ -82,7 +90,15 @@ def restore_writable_permissions(governance_dir: Path) -> None:
 
     Args:
         governance_dir: Path to .hestai-sys/ directory
+
+    Raises:
+        ValueError: If governance_dir is itself a symlink (root-level substitution attack)
     """
+    if governance_dir.is_symlink():
+        raise ValueError(
+            f"governance_dir is a symlink — potential root-level substitution attack: "
+            f"{governance_dir}"
+        )
     if not governance_dir.exists():
         return
 
@@ -141,7 +157,15 @@ def compute_governance_hash(governance_dir: Path) -> str:
 
     Returns:
         64-character hex SHA256 hash string
+
+    Raises:
+        ValueError: If governance_dir is itself a symlink (root-level substitution attack)
     """
+    if governance_dir.is_symlink():
+        raise ValueError(
+            f"governance_dir is a symlink — potential root-level substitution attack: "
+            f"{governance_dir}"
+        )
     hasher = hashlib.sha256()
 
     # Collect all file paths relative to governance_dir, sorted
@@ -182,6 +206,12 @@ def verify_governance_integrity(governance_dir: Path) -> dict:
         dict with 'intact' (bool), optionally 'reason' (str),
         'first_run' (bool)
     """
+    if governance_dir.is_symlink():
+        return {
+            "intact": False,
+            "reason": ("governance_dir is a symlink — potential root-level substitution attack"),
+        }
+
     integrity_file = governance_dir / ".integrity"
 
     if not integrity_file.exists():
@@ -213,7 +243,15 @@ def store_governance_hash(governance_dir: Path) -> str:
 
     Returns:
         The computed hash string
+
+    Raises:
+        ValueError: If governance_dir is itself a symlink (root-level substitution attack)
     """
+    if governance_dir.is_symlink():
+        raise ValueError(
+            f"governance_dir is a symlink — potential root-level substitution attack: "
+            f"{governance_dir}"
+        )
     gov_hash = compute_governance_hash(governance_dir)
     integrity_file = governance_dir / ".integrity"
     integrity_file.write_text(gov_hash)

--- a/tests/unit/mcp/tools/shared/test_governance_integrity.py
+++ b/tests/unit/mcp/tools/shared/test_governance_integrity.py
@@ -327,3 +327,124 @@ class TestVerifyGovernanceIntegrity:
 
         assert result["intact"] is True
         assert result["first_run"] is True
+
+    def test_verify_governance_integrity_rejects_symlinked_governance_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """Returns intact=False when governance_dir is itself a symlink (root-level substitution)."""
+        from hestai_mcp.modules.tools.shared.governance_integrity import (
+            verify_governance_integrity,
+        )
+
+        # Create a real directory with content
+        real_dir = tmp_path / "real_governance"
+        real_dir.mkdir()
+        (real_dir / "CONSTITUTION.md").write_text("real content")
+
+        # Create a symlink that points to the real directory
+        symlink_dir = tmp_path / "symlink_governance"
+        symlink_dir.symlink_to(real_dir)
+
+        assert symlink_dir.is_symlink()
+
+        result = verify_governance_integrity(symlink_dir)
+
+        assert result["intact"] is False
+        assert "reason" in result
+        assert "symlink" in result["reason"].lower()
+
+
+@pytest.mark.unit
+class TestComputeGovernanceHashSymlinkRejection:
+    """Test that compute_governance_hash rejects symlinked governance dir."""
+
+    def test_compute_governance_hash_rejects_symlinked_governance_dir(self, tmp_path: Path) -> None:
+        """Raises ValueError when governance_dir is itself a symlink."""
+        from hestai_mcp.modules.tools.shared.governance_integrity import (
+            compute_governance_hash,
+        )
+
+        real_dir = tmp_path / "real_governance"
+        real_dir.mkdir()
+        (real_dir / "CONSTITUTION.md").write_text("real content")
+
+        symlink_dir = tmp_path / "symlink_governance"
+        symlink_dir.symlink_to(real_dir)
+
+        assert symlink_dir.is_symlink()
+
+        with pytest.raises(ValueError, match="symlink"):
+            compute_governance_hash(symlink_dir)
+
+
+@pytest.mark.unit
+class TestApplyReadonlyPermissionsSymlinkRejection:
+    """Test that apply_readonly_permissions rejects symlinked governance dir."""
+
+    def test_apply_readonly_permissions_rejects_symlinked_governance_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """Raises ValueError when governance_dir is itself a symlink."""
+        from hestai_mcp.modules.tools.shared.governance_integrity import (
+            apply_readonly_permissions,
+        )
+
+        real_dir = tmp_path / "real_governance"
+        real_dir.mkdir()
+        (real_dir / "CONSTITUTION.md").write_text("real content")
+
+        symlink_dir = tmp_path / "symlink_governance"
+        symlink_dir.symlink_to(real_dir)
+
+        assert symlink_dir.is_symlink()
+
+        with pytest.raises(ValueError, match="symlink"):
+            apply_readonly_permissions(symlink_dir)
+
+
+@pytest.mark.unit
+class TestRestoreWritablePermissionsSymlinkRejection:
+    """Test that restore_writable_permissions rejects symlinked governance dir."""
+
+    def test_restore_writable_permissions_rejects_symlinked_governance_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """Raises ValueError when governance_dir is itself a symlink."""
+        from hestai_mcp.modules.tools.shared.governance_integrity import (
+            restore_writable_permissions,
+        )
+
+        real_dir = tmp_path / "real_governance"
+        real_dir.mkdir()
+        (real_dir / "CONSTITUTION.md").write_text("real content")
+
+        symlink_dir = tmp_path / "symlink_governance"
+        symlink_dir.symlink_to(real_dir)
+
+        assert symlink_dir.is_symlink()
+
+        with pytest.raises(ValueError, match="symlink"):
+            restore_writable_permissions(symlink_dir)
+
+
+@pytest.mark.unit
+class TestStoreGovernanceHashSymlinkRejection:
+    """Test that store_governance_hash rejects symlinked governance dir."""
+
+    def test_store_governance_hash_rejects_symlinked_governance_dir(self, tmp_path: Path) -> None:
+        """Raises ValueError when governance_dir is itself a symlink."""
+        from hestai_mcp.modules.tools.shared.governance_integrity import (
+            store_governance_hash,
+        )
+
+        real_dir = tmp_path / "real_governance"
+        real_dir.mkdir()
+        (real_dir / "CONSTITUTION.md").write_text("real content")
+
+        symlink_dir = tmp_path / "symlink_governance"
+        symlink_dir.symlink_to(real_dir)
+
+        assert symlink_dir.is_symlink()
+
+        with pytest.raises(ValueError, match="symlink"):
+            store_governance_hash(symlink_dir)


### PR DESCRIPTION
## Summary
- **Symlink hardening** from CRS+CE review feedback on PR #249: `followlinks=False` on all `os.walk` calls, symlink skipping in hash computation and permission functions, 2 new tests
- **Session boundary integrity verification**: `verify_governance_integrity()` wired into both clock_in and clock_out in `server.py`
- **Self-healing**: When tampering detected at session boundaries, automatic re-injection from bundled hub via `inject_system_governance()`

## Issue
Completes #235 — all three layers of the Holographic Constitution are now implemented:
- **Layer 1**: chmod 444/555 read-only permissions (haptic feedback) — PR #249
- **Layer 2**: SHA256 content hashing (mathematical certainty) — PR #249
- **Layer 3**: Self-healing at session boundaries (making tampering futile) — this PR

## Changes

### Symlink hardening (review feedback from PR #249)
- `governance_integrity.py`: `followlinks=False` on all 3 `os.walk` calls + `os.path.islink()` filtering
- 2 new tests: `restore_writable_permissions` nonexistent path + symlink ignored during hash

### Session boundary integrity
- `server.py` clock_in branch: verify governance integrity after `ensure_system_governance()`, self-heal if tampered
- `server.py` clock_out branch: verify governance integrity before archival, self-heal if tampered
- Both skip gracefully when `.hestai-sys` doesn't exist

### Tests (4 new, 73 total across affected files)
- `test_clock_in_detects_and_heals_tampering`
- `test_clock_in_passes_when_governance_intact`
- `test_clock_out_detects_and_heals_tampering`
- `test_clock_in_skips_integrity_check_when_no_hestai_sys`

## Test plan
- [ ] CI pipeline passes (ruff, black, mypy, pytest)
- [ ] Verify tampering at clock_in triggers self-healing
- [ ] Verify tampering at clock_out triggers self-healing
- [ ] Verify intact governance passes without self-healing
- [ ] Verify graceful skip when .hestai-sys absent
- [ ] Review: CRS + CE via submit_review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>