### PR TITLE
fix: correct stale file references after .hestai reorganisation

### DIFF
--- a/.hestai/rules/ci-progressive-testing.oct.md
+++ b/.hestai/rules/ci-progressive-testing.oct.md
@@ -8,7 +8,7 @@ META:
   TYPE::WORKFLOW
   STATUS::ACTIVE
   PURPOSE::"Define NOW/SOON/LATER test routing and required CI gates"
-  CANONICAL::.hestai/workflow/test-context/ci-progressive-testing.oct.md
+  CANONICAL::.hestai/rules/ci-progressive-testing.oct.md
 
 FOUNDATION::[
   NORTH_STAR::docs/workflow/000-MCP-PRODUCT-NORTH-STAR.md

--- a/.hestai/rules/octave-integration-guide.oct.md
+++ b/.hestai/rules/octave-integration-guide.oct.md
@@ -10,7 +10,7 @@ META:
   OWNERS::[system-steward]
   CREATED::2025-12-21
   UPDATED::2025-12-23
-  CANONICAL::.hestai/workflow/octave-integration-guide.oct.md
+  CANONICAL::.hestai/rules/octave-integration-guide.oct.md
   TAGS::[octave, internal, hestai-mcp]
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,7 +219,7 @@ MCP server starts (bootstrap_system_governance)
 
 ### What Goes in Hub?
 
-Per `src/hestai_mcp/_bundled_hub/governance/rules/hub-authoring-rules.oct.md`:
+Per `.hestai/rules/hub-authoring-rules.oct.md`:
 - **System governance** - Rules that apply to ALL HestAI consumers
 - **Agent constitutions** - Templates for agent roles
 - **Reusable components** - Commands, skills, patterns

--- a/docs/odyssean-anchor-terminology.md
+++ b/docs/odyssean-anchor-terminology.md
@@ -130,4 +130,4 @@ Note: `ARM` is intentionally removed from runtime headers to avoid collision wit
 ## References
 
 - ADR-0036: Odyssean Anchor Binding Architecture
-- `.hestai/north-star/specs/odyssean-anchor-tool-spec.oct.md`
+- `.hestai/state/context/.archive/specs/odyssean-anchor-tool-spec.oct.md` (archived, superseded by implementation)

--- a/src/hestai_mcp/_bundled_hub/governance/rules/visibility-rules.oct.md
+++ b/src/hestai_mcp/_bundled_hub/governance/rules/visibility-rules.oct.md
@@ -409,7 +409,7 @@ WITH_NAMING_STANDARD::[
 
 WITH_HUB_AUTHORING_RULES::[
   .hestai-sys/governance/rules/visibility-rules.oct.md→answers["WHERE in PRODUCT?"],
-  .hestai-sys/governance/rules/hub-authoring-rules.oct.md→answers["WHERE in SYSTEM governance payload?" ]
+  .hestai/rules/hub-authoring-rules.oct.md→answers["WHERE in SYSTEM governance payload?" ]
 ]
 
 ===AUTHORITY===


### PR DESCRIPTION
## Summary

Follow-up to #277. Addresses stale references identified by CE review:

- **Moved files**: `ci-progressive-testing.oct.md` and `octave-integration-guide.oct.md` still declared canonical paths under old `.hestai/workflow/` — corrected to `.hestai/rules/`
- **visibility-rules source**: Hub-authoring reference pointed to `.hestai-sys/` where the file never existed — corrected to `.hestai/rules/` (project-level rule)
- **ARCHITECTURE.md**: Referenced hub-authoring-rules in `_bundled_hub/` source path — corrected to `.hestai/rules/`
- **odyssean-anchor-terminology.md**: Referenced archived spec at old `north-star/specs/` location — corrected to `.hestai/state/context/.archive/specs/`

**Not changed**: ADR files referencing `.hestai/workflow/` — these are historical records describing the architecture at the time of the decision and should not be retroactively modified.

## Test plan

- [x] Pre-commit hooks pass (OCTAVE validation, naming/visibility, mypy)
- [x] Ruff and black checks pass
- [ ] Verify no remaining broken references to old paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)