### PR TITLE
docs: add phase deliverable placement rules and canonicalize workflow…

### DIFF
--- a/docs/hestai-sys-visibility-solution.md
+++ b/docs/hestai-sys-visibility-solution.md
@@ -15,14 +15,17 @@ This creates a paradox: The governance that should guide agents is invisible to 
 ```
 .hestai-sys/
 ├── governance/       # Rules agents should follow
-│   ├── rules/       # Naming standards, visibility rules
-│   └── workflow/    # North Stars, methodology
-├── agents/          # Agent constitutions
-├── library/         # Commands, skills, specs
-│   ├── commands/    # Like /bind command
-│   ├── skills/      # Reusable patterns
-│   └── specs/       # Protocols (Odyssean Anchor, etc)
-└── templates/       # Project templates
+│   ├── rules/       # Naming standards, visibility rules, test standards
+│   └── workflow/    # System North Star, operational workflow
+├── agents/          # Agent constitution templates
+├── library/         # Skills, agents, patterns, schemas, OCTAVE guides
+│   ├── skills/      # Ecosystem-wide operational skills
+│   ├── agents/      # Agent definitions (.oct.md)
+│   ├── patterns/    # Reusable patterns and examples
+│   ├── schemas/     # Schema definitions
+│   └── octave/      # OCTAVE usage guides
+├── templates/       # Project scaffolding templates
+└── tools/           # System utility scripts (validators, checkers)
 ```
 
 ### How Agents Currently Access Governance
@@ -70,7 +73,7 @@ def discover_governance(working_dir: str) -> dict:
     Returns paths to:
     - System rules
     - Agent constitutions
-    - Commands and skills
+    - Skills and patterns
     - North Stars
     """
     hestai_sys = Path(working_dir) / ".hestai-sys"
@@ -82,8 +85,8 @@ def discover_governance(working_dir: str) -> dict:
         "governance_root": str(hestai_sys),
         "rules": list((hestai_sys / "governance/rules").glob("*.md")),
         "agent_constitutions": list((hestai_sys / "agents").glob("*.oct.md")),
-        "commands": list((hestai_sys / "library/commands").glob("*.md")),
         "skills": list((hestai_sys / "library/skills").glob("*/SKILL.md")),
+        "agents": list((hestai_sys / "library/agents").glob("*.oct.md")),
         "note": "These files are read-only system governance"
     }
 ```
@@ -103,7 +106,7 @@ if [ -d ".hestai-sys" ]; then
     echo "Key files:"
     echo "  • .hestai-sys/governance/rules/ - System rules"
     echo "  • .hestai-sys/agents/ - Agent constitutions"
-    echo "  • .hestai-sys/library/commands/bind.md - Binding ceremony"
+    echo "  • .hestai-sys/library/skills/ - Ecosystem-wide skills"
     echo "Note: These are read-only, delivered by MCP server"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 fi
@@ -124,8 +127,9 @@ These files are automatically managed and will be replaced on server restart.
 ## Contents
 - `governance/` - System rules and workflows
 - `agents/` - Agent constitutions
-- `library/` - Commands, skills, and specs
-- `templates/` - Project templates
+- `library/` - Skills, agents, patterns, schemas, OCTAVE guides
+- `templates/` - Project scaffolding templates
+- `tools/` - System utility scripts
 
 ## For Agents
 Use `Read` tool to access these files for governance guidance.

--- a/src/hestai_mcp/_bundled_hub/governance/rules/visibility-rules.oct.md
+++ b/src/hestai_mcp/_bundled_hub/governance/rules/visibility-rules.oct.md
@@ -3,13 +3,13 @@
 META:
   TYPE::STANDARD
   ID::visibility-rules
-  VERSION::"1.6"
+  VERSION::"1.7"
   STATUS::ACTIVE
   PURPOSE::"Placement and lifecycle rules for artifacts to ensure discoverability"
   DOMAIN::governance
   OWNERS::[system-steward]
   CREATED::2025-12-09
-  UPDATED::2026-02-26
+  UPDATED::2026-03-04
   CANONICAL::.hestai-sys/governance/rules/visibility-rules.oct.md
   SOURCE::src/hestai_mcp/_bundled_hub/governance/rules/visibility-rules.oct.md
   TAGS::[placement, visibility, documentation, lifecycle, hestai-sys, bundled-hub]
@@ -225,6 +225,7 @@ RULE_6::REPORTS→.hestai/state/reports/::[
   TRACKING::shared_across_worktrees[symlinked_to_.hestai-state/],
 
   WHAT_GOES_HERE::[
+    phase_gate_evidence[B0_validation|B1-B3_reports|implementation_logs],
     audit_reports[anchor_audits|gate_failures|integrity_checks],
     security_scan_outputs[redaction_summaries|findings],
     operational_diagnostics["why_clock_out_failed"],
@@ -272,7 +273,9 @@ PLACEMENT_TABLE::[
   governance_decisions→.hestai/decisions/[committed|governance|stable],
   project_rules→.hestai/rules/[committed|governance|stable],
   project_schemas→.hestai/schemas/[committed|governance|stable],
-  implementation_specs[active]→.hestai/rules/specs/[committed|governance|phase_scoped],
+  phase_specs[D2+D3+B1]→.hestai/rules/specs/[committed|governance|phase_scoped],
+  phase_reports[B0-B3]→.hestai/state/reports/[shared|evidence|timestamped],
+  phase_docs[B4_graduated]→docs/[committed|developers|permanent],
   implementation_specs[superseded]→.hestai/state/context/.archive/specs/[shared|ephemeral|archived],
 
   // PROJECT WORKING STATE (.hestai/state/ - shared via symlink, no PR)
@@ -287,6 +290,41 @@ PLACEMENT_TABLE::[
   // CLAUDE CODE INFRASTRUCTURE (.claude/)
   agent_constitutions→.claude/agents/[committed|Claude_Code|infrastructure],
   project_skills→.claude/skills/[committed|Claude_Code|infrastructure]
+]
+
+===PHASE_DELIVERABLES===
+
+// Lifecycle model: Spec (the plan) → Report (the evidence) → Doc (the product)
+// Artifacts graduate through the lifecycle as phases progress
+
+LIFECYCLE_PRIMITIVE::[
+  SPEC[the_plan]→.hestai/rules/specs/[active_mutable_guidance],
+  REPORT[the_evidence]→.hestai/state/reports/[timestamped_immutable_evidence],
+  DOC[the_product]→docs/[permanent_developer_facing]
+]
+
+PHASE_MAPPING::[
+  D1_NORTH_STAR→.hestai/north-star/[immutable_anchor],
+  D2_IDEAS_CONSTRAINTS_DESIGN→.hestai/rules/specs/[active_spec],
+  D3_BLUEPRINT→.hestai/rules/specs/[spec_MIGRATES_to_docs/_at_B1_gate],
+  B0_VALIDATION→.hestai/state/reports/[gate_evidence|architectural_reasoning→docs/adr/],
+  B1_BUILD_PLAN→.hestai/rules/specs/[task_breakdown_for_B2],
+  B2_IMPLEMENTATION_LOG→.hestai/state/reports/[evidence_stream],
+  B3_QA_SECURITY→.hestai/state/reports/[audit_trail],
+  B4_HANDOFF_USER_GUIDE→docs/[graduated_permanent_documentation]
+]
+
+GRADUATION_RULES::[
+  D3_blueprint→migrates_from_.hestai/rules/specs/_to_docs/_at_B1_gate,
+  B0_architectural_decisions→recorded_as_ADRs_in_docs/adr/,
+  B4_handoff_docs→graduate_from_draft_to_docs/_at_delivery
+]
+
+ADR_SUPREMACY::[
+  RULE::"When in doubt between .hestai/decisions/ and docs/adr/ → choose docs/adr/",
+  .hestai/decisions/→reserved_for_meta-governance[constitutional_amendments_only],
+  docs/adr/→all_architecture_implementation_design_decisions,
+  .hestai/state/reports/→gate_passage_evidence[B0-B3]
 ]
 
 ===ANTI_PATTERNS===
@@ -443,6 +481,7 @@ COMPANION::naming-standard.md[naming+frontmatter_logic]
 
 ===CHANGELOG===
 
+v1.7::2026-03-04→added_PHASE_DELIVERABLES_section[lifecycle_model:Spec→Report→Doc]+phase_mapping_D1-B4+graduation_rules+ADR_SUPREMACY_policy+phase_deliverables_in_PLACEMENT_TABLE+phase_gate_evidence_in_RULE_6
 v1.6::2026-02-26→fixed_ADR_path_to_docs/adr/[per_ADR-0031]+clarified_.hestai/decisions/_as_compiled_governance_decisions[not_ADRs]+expanded_.hestai-sys/library/_structure[skills/agents/patterns/schemas/octave]+added_system_skills_to_RULE_0+added_skill_distinction_NOTE_to_RULE_5+added_CONFUSE_DECISIONS_WITH_ADRS_anti-pattern+added_system_skills_to_PLACEMENT_TABLE
 v1.5::2026-02-23→clarified_north-star_folder_strict_contents+expanded_rules_folder_scope+added_implementation_spec_placement+anti-pattern_for_north-star_contamination
 v1.4::2025-12-27→added_FILE_RETENTION_POLICY_section[ADR-0060_ratification]

--- a/src/hestai_mcp/_bundled_hub/governance/workflow/OPERATIONAL-WORKFLOW.oct.md
+++ b/src/hestai_mcp/_bundled_hub/governance/workflow/OPERATIONAL-WORKFLOW.oct.md
@@ -7,7 +7,7 @@ META:
   DOMAIN::workflow
   OWNERS::["system-steward"]
   CREATED::"2026 -01 -08"
-  UPDATED::"2026 -01 -13"
+  UPDATED::"2026-03-04"
   CANONICAL::".hestai-sys/governance/workflow/OPERATIONAL-WORKFLOW.oct.md"
   SOURCE::"src/hestai_mcp/_bundled_hub/governance/workflow/OPERATIONAL-WORKFLOW.oct.md"
   FORMAT::octave
@@ -40,28 +40,28 @@ NATURAL_FLOW::"D1 maintains natural conversational flow rather than artificial s
 RACI::"R[phase_specialists]→A[critical-engineer:North_Star_complete+correct]→C[none:not_building_yet]→I[none:no_implementation_teams]"
 DELIVERABLE::"0xx-PROJECT[-NAME]-NORTH-STAR.md+immutable_requirements[7±2]+assumption_audit+commitment_ceremony_approval"
 NORTH_STAR_ARCHITECTURE::"4-layer structure: immutable_core[5-9] + constrained_variables + assumption_register + explicit_non-requirements"
-LOCATION::"@coordination/docs/workflow/[post-graduation_distribution]"
+LOCATION::".hestai/north-star/"
 D2_ATHENA_INNOVATION::SOLUTION_APPROACHES
 SUBPHASES::"D2_01[ideator+edge-optimizer:creative_breakthrough]→D2_02[validator:feasibility_constraints]→D2_02B[edge-optimizer:additional_exploration:OPTIONAL]→D2_03[synthesizer:unified_approach]"
 DUAL_ROLE_EDGE::"edge-optimizer contributes to D2_01 for breakthrough creative exploration AND D2_02B for boundary exploration"
 RACI::"R[phase_specialists, edge-optimizer:D2_01+D2_02B_optional]→A[critical-engineer:synthesis_completeness+feasibility]→C[requirements-steward:North_Star, technical-architect:feasibility]→I[none:design_phase]"
 DELIVERABLES::["D2_01-IDEAS.md","D2_02-CONSTRAINTS.md","D2_02B-EDGE_DISCOVERIES.md:optional","D2_03-DESIGN.md"]
 EDGE_INTEGRATION::"D2_02B_discoveries→optional_input_to_D2_03_synthesis"
-LOCATION::"@coordination/docs/workflow/"
+LOCATION::".hestai/rules/specs/"
 SIGNOFF_REQUIRED::"D2_01[ideator]+D2_02[validator] approve D2_03[synthesis] before D3"
 D3_DAEDALUS_CONSTRUCTION::TECHNICAL_BLUEPRINT
 SUBPHASES::"D3_01[design-architect:technical_architecture]→D3_02[visual-architect:mockups+user_validation]→D3_03[technical-architect:validation]→D3_04[security-specialist:security+compliance]"
 VISUAL_VALIDATION::"create_mockups→user_validation→IF[significant_changes]→CONSULT[design-architect+requirements-steward]→iterate→approval"
 RACI::"R[phase_specialists]→A[critical-engineer:completeness+production_readiness]→C[requirements-steward:alignment, design-architect:changes]→I[implementation-lead:build_prep]"
 DELIVERABLES::["D3-BLUEPRINT.md⊕complete_spec","D3-MOCKUPS.md⊕validation","D3-VISUAL-DECISIONS.md⊕rationale"]
-LOCATION::"@coordination/docs/workflow/"
+LOCATION::".hestai/rules/specs/[migrates_to_docs/_at_B1_gate]"
 B0_THEMIS_JUDGMENT::VALIDATION_GATE
 PURPOSE::"Critical design validation→GO/NO-GO decision for build phase"
 SUBPHASES::"B0_01[critical-design-validator:completeness+failure_modes]→B0_02[requirements-steward:North_Star_alignment]→B0_03[technical-architect:feasibility+scalability]→B0_04[critical-engineer:GO/NO-GO_decision]"
 RACI::"R[validation_specialists]→A[critical-engineer:final_GO/NO-GO_authority]→C[security-specialist:security, error-architect:failure_modes, principal-engineer:long_term_viability]→I[implementation-lead, solution-steward, task-decomposer]"
 ENTRY_REQUIREMENTS::["NORTH-STAR.md⊕approved⊕immutable","D2-DESIGN.md⊕validated","D3-BLUEPRINT.md⊕complete",assumption_audits_complete]
 DELIVERABLE::"B0-VALIDATION.md+GO/NO-GO_decision"
-LOCATION::"@dev/reports/"
+LOCATION::".hestai/state/reports/[gate_evidence|architectural_decisions→docs/adr/]"
 VALIDATION_CRITERIA::[North_Star_alignment,"architecture_sound⊕scalable⊕implementable",security_addressed,assumptions_validated,resources_realistic,no_blocking_risks]
 EXIT::"GO[proceed_B1] | NO-GO[return_D-phase]"
 B1_HERMES_COORDINATION::BUILD_EXECUTION_ROADMAP
@@ -72,7 +72,7 @@ MIGRATION_GATE::"B1_02_completion→STOP→HUMAN_MIGRATION_POINT"
 RESTART_IN_NEW_LOCATION::"cd ${PROJECT_ROOT}/build/VERIFY_pwd→RESUME_B1_03"
 QUALITY_GATE_MANDATORY::"⚠️ Load workspace-setup skill for stack-specific gates. NO src/ FILES WITHOUT PASSING quality gates per project stack: python[ruff_check,black_check,mypy,pytest] | node[npm_run_lint,npm_run_typecheck,npm_test] | generic[lint,typecheck,test]"
 DELIVERABLES::["B1-BUILD-PLAN.md⊕task_breakdown","B1-WORKSPACE.md⊕environment⊕CI/CD_setup⊕QUALITY_GATE_EVIDENCE","B1-DEPENDENCIES.md⊕critical_path",TRACED_artifacts]
-LOCATION::"@dev/reports/"
+LOCATION::".hestai/rules/specs/[build_plan]+.hestai/state/reports/[gate_evidence]"
 CRITERIA::[all_components_have_tasks,"dependencies_mapped⊕sequenced",test_requirements_identified,QUALITY_GATES_OPERATIONAL,resources_defined,risks_mitigated,"timeline_realistic⊕buffered"]
 CONTEXT7_LIBRARY_RESEARCH::[[[PATTERN::"mcp__Context7__resolve-library-id→mcp__Context7__get-library-docs"]],[[D1_USAGE::"Research for problem understanding and existing solutions"]],[[B0_USAGE::"Architecture validation against current library capabilities"]],[[B1_USAGE::"Dependency versions and integration patterns"]],[[B2_USAGE::"API references and implementation examples during TDD"]],[[B3_USAGE::"Integration best practices and compatibility validation"]]]
 B2_HEPHAESTUS_FORGE::CODE_CONSTRUCTION
@@ -83,7 +83,7 @@ B2_00_REQUIREMENTS::[test_strategy_aligned,coverage_requirements_defined,complia
 IMPLEMENTATION_STANDARDS::["TEST_STRATEGY_FIRST→TEST_FIRST→TRACED_METHODOLOGY",Context7_consultation_libraries,code_review_every_change,CI_immediate_failure_resolution,architecture_compliance,security_scanning]
 QUALITY_GATES::["coverage_80%+",tests_passing_CI,code_review_approval,no_critical_vulnerabilities,performance_benchmarks_met,docs_updated]
 DELIVERABLES::["B2-IMPLEMENTATION-LOG.md","B2-TEST-STRATEGY.md","source_code⊕tests","CI_pipeline⊕quality_gates",TRACED_compliance_artifacts]
-LOCATION::"@dev/reports/"
+LOCATION::".hestai/state/reports/"
 B3_HARMONIA_UNIFICATION::SYSTEM_UNIFICATION
 PURPOSE::"Unify components→cohesive system+validate end-to-end functionality+production readiness"
 SUBPHASES::"B3_01[completion-architect:integration+coherence]→B3_02[universal-test-engineer:integration+E2E+performance]→B3_02B[edge-optimizer:breakthrough_optimization:OPTIONAL]→B3_03[security-specialist:security_audit+penetration]→B3_04[coherence-oracle:cross-system_consistency]"
@@ -92,14 +92,14 @@ INTEGRATION_VALIDATION::[component_interface_compatibility,"data_flow⊕state_ma
 SYSTEM_TESTING::[integration_tests_all_interactions,E2E_user_journey_validation,performance_benchmarks_achieved,security_penetration_passed,disaster_recovery_validated,"monitoring⊕observability_confirmed"]
 DELIVERABLES::["B3-INTEGRATION-REPORT.md","B3-PERFORMANCE.md","B3-BREAKTHROUGH_OPTIMIZATIONS.md:optional","B3-SECURITY.md","fully_integrated_system⊕E2E_tests"]
 BREAKTHROUGH_INTEGRATION::"B3_02B_optimizations→evaluated_by_completion-architect_for_system_integration"
-LOCATION::"@dev/reports/"
+LOCATION::".hestai/state/reports/"
 B4_IRIS_HANDOFF::PRODUCTION_HANDOFF
 PURPOSE::"Complete solution preparation for production deployment+comprehensive documentation+operational readiness"
 SUBPHASES::"B4_01[solution-steward:package+docs+handoff]→B4_02[system-steward:architecture+operations+maintenance]→B4_03[workspace-architect:cleanup+publication_readiness]→B4_04[security-specialist:final_review+hardening]→B4_05[critical-engineer:production_readiness+signoff]"
 DEPLOY_PHASES::"B4_D1[staging+validation]→B4_D2[live+production]→B4_D3[post-deployment+monitoring]"
 RACI::"R[delivery_specialists, critical-engineer:deployment_phases]→A[critical-engineer:production_release+deployment_authority]→C[technical-architect:architecture_docs, implementation-lead:knowledge_transfer, principal-engineer:operational_sustainability]→I[completion-architect, requirements-steward]"
 DELIVERABLES::["B4-HANDOFF.md","B4-OPERATIONS.md⊕runbooks","B4-USER-GUIDE.md","B4-MAINTENANCE.md","B4-WORKSPACE.md⊕publication_ready","deployment_packages⊕config",training_materials]
-LOCATION::"@dev/reports/"
+LOCATION::"docs/[graduated_permanent_documentation]"
 PRODUCTION_READINESS::["infrastructure_provisioned⊕tested",deployment_procedures_validated,rollback_tested,"monitoring⊕alerting_active",security_scanning_complete,load_testing_passed,docs_approved,support_trained]
 B5_PROMETHEUS_EVOLUTION::POST_DELIVERY_ENHANCEMENT
 PURPOSE::"Feature expansion+architectural enhancement without full D1→B4 restart"
@@ -125,12 +125,13 @@ POST_MORTEM_ANALYSIS:
   COLLABORATION_PATTERN::"critical-engineer produces incident analysis→principal-engineer consumes for pattern extraction→joint recommendations (tactical fixes + strategic prevention)"
   DELIVERABLE::"Post-mortem report with tactical remediation AND strategic architectural recommendations"
   INVOCATION::"MANDATORY for CRITICAL incidents, HIGH-priority recurring failures, architectural erosion signals"
-COORDINATION_ARCHITECTURE:
-  TWO_REPOSITORY_PATTERN::[[[DEV_REPOSITORY::"docs/*[ALL_technical_docs], src/, tests/"]],[[COORDINATION_REPOSITORY::"workflow-docs/[phase_artifacts], phase-reports/[B1-B4], planning-docs/[CHARTER,ASSIGNMENTS], ACTIVE-WORK.md[visibility]"]]]
+ARTIFACT_PLACEMENT:
+  LIFECYCLE_MODEL::"Spec[.hestai/rules/specs/]→Report[.hestai/state/reports/]→Doc[docs/]"
   DOCUMENT_PLACEMENT_PROTOCOL::"Load documentation-placement skill for placement rules and visibility protocols"
+  CANONICAL_REFERENCE::".hestai-sys/governance/rules/visibility-rules.oct.md"
   PHASE_TRANSITION_CLEANUP::["B1_02, B2_04, B3_04, B4_05 require cleanup validation","holistic-orchestrator→directory-curator→workspace-architect pattern"]
 SESSION_COORDINATION:
-  IDEATION_GRADUATION_EXECUTION::[[[D0_IDEATION::"{IDEATION_ROOT}/sessions/[structured_exploration+thread_messaging+manifest_tracking]"]],[[PROJECT_MIGRATION_EXECUTION::"workspace-architect[B1_02]→migration[ideation→{project-name}/sessions/]→MIGRATION_GATE[directory_change_required]→state_symlink[.hestai/state/]→using_graduation_assessment_from_D0"]],[[ARTIFACT_DISTRIBUTION::"D-phase→@coordination/docs/workflow/, B-phase→@dev/reports/"]]]
+  IDEATION_GRADUATION_EXECUTION::[[[D0_IDEATION::".hestai/state/sessions/[structured_exploration+thread_messaging+manifest_tracking]"]],[[PROJECT_MIGRATION_EXECUTION::"workspace-architect[B1_02]→migration[ideation→project/sessions/]→MIGRATION_GATE[directory_change_required]→state_symlink[.hestai/state/]→using_graduation_assessment_from_D0"]],[[ARTIFACT_DISTRIBUTION::"D1→.hestai/north-star/, D2-D3→.hestai/rules/specs/, B0-B3→.hestai/state/reports/, B4→docs/"]]]
   LINK_STANDARDS::[[[LOCALITY_PRINCIPLE::"internal_links[relative_paths], external_links[full_paths_boundary_crossing_only]"]],[[MIGRATION_RESILIENCE::"links_survive_reorganization+repository_moves"]],[[VALIDATION_ENFORCEMENT::"automation_testable+broken_links_block_commits"]]]
 ENHANCEMENT_CLASSIFICATION:
   B5_CRITERIA::[improves_existing_beyond_original,works_within_architectural_framework,completable_within_scope_limits,low_destabilization_risk]

--- a/src/hestai_mcp/_bundled_hub/library/skills/documentation-placement/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/documentation-placement/SKILL.md
@@ -8,7 +8,7 @@ triggers: ["documentation placement", "ADR placement", "phase artifact", "docume
 ===DOCUMENTATION_PLACEMENT===
 META:
   TYPE::SKILL
-  VERSION::"2.1"
+  VERSION::"2.2"
   STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
   DOMAIN::HERMES[communication]+HESTIA[structure]
@@ -29,7 +29,7 @@ CANONICAL_REFERENCE::.hestai-sys/governance/rules/visibility-rules.oct.md
 
 §2::REPOSITORY_STRUCTURE
 
-// Per visibility-rules.oct.md v1.6
+// Per visibility-rules.oct.md v1.7
 
 SYSTEM_GOVERNANCE[.hestai-sys/]::[
   READ_ONLY[injected_from_src/hestai_mcp/_bundled_hub/],
@@ -85,15 +85,31 @@ NOTE::.claude/skills/→project_specific|.hestai-sys/library/skills/→ecosystem
 
 §3::PHASE_ARTIFACT_MAPPING
 
+// Lifecycle: Spec (the plan) → Report (the evidence) → Doc (the product)
+// Artifacts graduate through the lifecycle as phases progress
+
 PLACEMENT::[
-  D1_NORTH_STAR::.hestai/north-star/,
-  D2_DESIGN::.hestai/rules/specs/,
-  D3_BLUEPRINT::docs/[architecture_documentation],
-  B0_VALIDATION::.hestai/rules/specs/,
-  B1_B4_REPORTS::.hestai/state/reports/
+  D1_NORTH_STAR::.hestai/north-star/[immutable_anchor],
+  D2_IDEAS_CONSTRAINTS_DESIGN::.hestai/rules/specs/[active_spec],
+  D3_BLUEPRINT::.hestai/rules/specs/[spec_MIGRATES_to_docs/_at_B1_gate],
+  B0_VALIDATION::.hestai/state/reports/[gate_evidence],
+  B1_BUILD_PLAN::.hestai/rules/specs/[task_breakdown_for_B2],
+  B2_IMPLEMENTATION_LOG::.hestai/state/reports/[evidence_stream],
+  B3_QA_SECURITY::.hestai/state/reports/[audit_trail],
+  B4_HANDOFF_USER_GUIDE::docs/[graduated_permanent_documentation]
 ]
 
-CRITICAL::"D3 blueprint migrates to docs/ at B1 gate"
+GRADUATION_RULES::[
+  D3_blueprint→migrates_from_.hestai/rules/specs/_to_docs/_at_B1_gate,
+  B0_architectural_decisions→recorded_as_ADRs_in_docs/adr/,
+  B4_handoff_docs→graduate_from_draft_to_docs/_at_delivery
+]
+
+ADR_SUPREMACY::[
+  RULE::"When in doubt between .hestai/decisions/ and docs/adr/ → choose docs/adr/",
+  .hestai/decisions/→reserved_for_meta-governance[constitutional_amendments_only],
+  docs/adr/→all_architecture_implementation_design_decisions
+]
 
 §4::FORMAT_SELECTION
 


### PR DESCRIPTION
… paths

- Add PHASE_DELIVERABLES section to visibility-rules (v1.7) with lifecycle model: Spec→Report→Doc and canonical D1-B4 mapping
- Add ADR_SUPREMACY policy: when in doubt, use docs/adr/ not .hestai/decisions/
- Add GRADUATION_RULES: D3 migrates at B1, B4 docs graduate to docs/
- Update OPERATIONAL-WORKFLOW: replace all @coordination/@dev LOCATION references with canonical .hestai/ paths, remove two-repo pattern
- Update documentation-placement skill (v2.2): refined §3 phase mapping with per-phase locations and graduation rules
- Update docs/hestai-sys-visibility-solution.md: fix stale .hestai-sys/ tree structure to match actual library/ subdirectories