### PR TITLE
feat: trigger codex review after review gate passes

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -248,16 +248,25 @@ jobs:
         with:
           script: |
             const prNumber = process.env.PR_NUMBER;
-            const headSha = context.payload.pull_request?.head?.sha
-              || context.sha;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(prNumber)
+            });
+
+            const headSha = pr.head.sha;
             const marker = `<!-- codex-review-request-${headSha} -->`;
 
             // Check if we already requested a review for this SHA
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(prNumber),
+                per_page: 100
+              }
+            );
 
             const existing = comments.find(c =>
               c.user.type === 'Bot' && c.body.includes(marker)


### PR DESCRIPTION
## Summary
- Adds a new "Request Codex Review" step to the review-gate workflow that posts `@codex review` as a PR comment when the gate passes
- Uses SHA-based dedup (`<!-- codex-review-request-{SHA} -->`) to prevent duplicate requests on re-runs while allowing new reviews on new pushes
- Runs across all 8 repos via the existing governance socket pattern

## Test plan
- [ ] Verify workflow syntax is valid (CI will check)
- [ ] Confirm `@codex review` comment appears on a PR where the review gate passes
- [ ] Confirm no duplicate comment on workflow re-run for the same commit
- [ ] Confirm new comment appears after a new push (different SHA)
- [ ] Verify cross-repo behavior via a consuming repo's `workflow_call`

🤖 Generated with [Claude Code](https://claude.com/claude-code)