### PR TITLE
fix(review-gate): filter issue_comment triggers to review verdict keywords

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -29,6 +29,8 @@ jobs:
     # Only run on PR events, workflow_call, or PR comments containing review verdicts.
     # Filters out irrelevant comments (discussion, bot noise) that can't change gate outcome.
     # Keywords match review_formats.py: APPROVED, REVIEWED (covers SELF-REVIEWED), GO.
+    # Also matches markdown-bold variants (**APPROVED**, **GO**) since review_formats.py
+    # strips bold markers before pattern matching.
     if: >-
       github.event_name == 'pull_request'
       || github.event_name == 'workflow_call'
@@ -36,7 +38,8 @@ jobs:
           && (contains(github.event.comment.body, 'APPROVED')
               || contains(github.event.comment.body, 'REVIEWED')
               || contains(github.event.comment.body, ' GO')
-              || contains(github.event.comment.body, ' GO:')))
+              || contains(github.event.comment.body, ' GO:')
+              || contains(github.event.comment.body, '**GO**')))
 
     # Required for PR commenting
     permissions:


### PR DESCRIPTION
## Summary
- Filter `issue_comment` workflow triggers to only re-run when the comment contains review verdict keywords (`APPROVED`, `REVIEWED`, `GO`)
- Eliminates wasted workflow runs from irrelevant PR comments (discussion, bot noise) that can't change the gate outcome
- Keywords align with `review_formats.py` patterns: covers all tier verdicts (IL SELF-REVIEWED, HO REVIEWED, CRS/CE APPROVED/GO)

## Test plan
- [ ] Open a PR and verify the gate runs on `pull_request` events as before
- [ ] Post a comment containing `CRS APPROVED: test` — gate should re-run
- [ ] Post a comment containing `IL SELF-REVIEWED: test` — gate should re-run
- [ ] Post an unrelated comment (e.g. "looks good") — gate should **not** re-run
- [ ] Verify `workflow_call` path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)