### PR TITLE
chore(deps): update octave-mcp from 1.7.0 to 1.9.0

### DIFF
--- a/.hestai/rules/octave-integration-guide.oct.md
+++ b/.hestai/rules/octave-integration-guide.oct.md
@@ -1,21 +1,21 @@
 ===HESTAI_MCP_OCTAVE_INTERNAL===
 META:
   TYPE::METHODOLOGY
-  ID::"hestai-mcp-octave-internal"
+  ID::hestai-mcp-octave-internal
   VERSION::"1.1"
   STATUS::ACTIVE
   PURPOSE::"HestAI-MCP internal OCTAVE integration notes (not for consumers)"
   DOMAIN::workflow
-  OWNERS::["system-steward"]
+  OWNERS::[system-steward]
   CREATED::"2025 -12 -21"
-  UPDATED::"2026-02-28"
+  UPDATED::"2026-03-07"
   CANONICAL::".hestai/rules/octave-integration-guide.oct.md"
   TAGS::[
     octave,
     internal,
-    "hestai-mcp"
+    hestai-mcp
   ]
-  OCTAVE_VERSION::"1.7.0"
+  OCTAVE_VERSION::"1.9.0"
 ---
 // This file is HestAI-MCP INTERNAL documentation.
 // Consumer-facing OCTAVE guide: .hestai-sys/library/octave/octave-usage-guide.oct.md
@@ -43,20 +43,25 @@ OCTAVE_SPEC::"/Volumes/OCTAVE/octave/specs/"
 CONSUMER_GUIDE::".hestai-sys/library/octave/octave-usage-guide.oct.md"
 PRODUCT_NORTH_STAR::".hestai/workflow/000-MCP-PRODUCT-NORTH-STAR.md"
 ADR_0033::"docs/adr/adr-0033-dual-layer-context-architecture.md"
-§4::OCTAVE_V1_7_FEATURES::[NEW_MCP_TOOLS::[
+§4::OCTAVE_V1_7_FEATURES
+NEW_MCP_TOOLS::[
   "octave_validate[schema_aware_validation]",
   "octave_write[unified_create_amend]",
   "octave_eject[multi_format_projection]",
   "octave_compile_grammar[GBNF_for_constrained_generation]"
-],NEW_PYTHON_API::[
+]
+NEW_PYTHON_API::[
   "seal_document()+verify_seal()[integrity_sealing]",
   "project()[4_modes:canonical/authoring/executive/developer]",
   "repair()[tier_classification:NORMALIZATION/REPAIR/FORBIDDEN]",
   "extract_schema_from_document()[holographic_schema_extraction]"
-],VALIDATION_PROFILES::[
+]
+VALIDATION_PROFILES::[
   "STRICT[full_compliance]",
   "STANDARD[default]",
   "LENIENT[auto_repair]",
   "ULTRA[minimal]"
-],HOLOGRAPHIC_CONTRACTS::"META.CONTRACT+META.GRAMMAR_blocks_enable_self_describing_documents",CONTEXT_STEWARD_STATUS::"API_COMPATIBLE[parse()+Document+Assignment+Block+Section_unchanged]"]
+]
+HOLOGRAPHIC_CONTRACTS::"META.CONTRACT+META.GRAMMAR_blocks_enable_self_describing_documents"
+CONTEXT_STEWARD_STATUS::"API_COMPATIBLE[parse()+Document+Assignment+Block+Section_unchanged]"
 ===END===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "keyring>=24.0.0",
     "pyyaml>=6.0",
-    "octave-mcp>=1.7.0",  # Official OCTAVE parser with GBNF export and holographic contracts
+    "octave-mcp>=1.9.0",  # Official OCTAVE parser with GBNF export and holographic contracts
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -383,7 +383,7 @@ requires-dist = [
     { name = "keyring", specifier = ">=24.0.0" },
     { name = "mcp", specifier = ">=0.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "octave-mcp", specifier = ">=1.7.0" },
+    { name = "octave-mcp", specifier = ">=1.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.7.0"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -718,9 +718,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/cd/f0444a851b607fdf47247d89c975e407351c7eb0c2660a573fa655178329/octave_mcp-1.7.0.tar.gz", hash = "sha256:b6678370a981ff42560a9db5d2c9594e9cc9d94443cc872648f432dff52366f4", size = 234484, upload-time = "2026-02-28T03:59:49.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/cf/e4f269863462db518784a13f18a17d245b8e0735c35d4be820559b0198a8/octave_mcp-1.9.0.tar.gz", hash = "sha256:bde383cfc665684ce72cb7e183a3c3ec2e0350127ec2354326b8b2a59c65bf1d", size = 253736, upload-time = "2026-03-07T01:15:07.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/bf/c4fdfe73b7030248df8d6a81b2b249cb6d3e4160f7ee4ca6a538a4d2d2d4/octave_mcp-1.7.0-py3-none-any.whl", hash = "sha256:990d421e994e7f927b94edf81018fb921c70b1d0528551be55a43e4d859b79ca", size = 252899, upload-time = "2026-02-28T03:59:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/3ab140388dc5444868ddaa0049bb6245cedb32aa398eaebbc08fc81bd3db/octave_mcp-1.9.0-py3-none-any.whl", hash = "sha256:7ad7712cc4ada4266d0f5589f18ca44d63c82b82b71a34026f0325df9dd83ace", size = 271885, upload-time = "2026-03-07T01:15:05.669Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `octave-mcp` dependency from `>=1.7.0` to `>=1.9.0` (resolved: 1.9.0)
- Updates internal integration guide version reference to 1.9.0
- v1.8.0 adds lexical fidelity (quote preservation for PATTERN/REGEX values, 3 new lint warnings)
- v1.9.0 adds cognitive type system (LOGOS/ETHOS/PATHOS), COGNITION_DEFINITION schema, agents-spec v7.0.0

## Test plan
- [x] All 705 tests pass
- [x] All pre-commit hooks pass (including OCTAVE validation)
- [x] `octave-mcp` 1.9.0 installs and imports correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)