### PR TITLE
fix(review-gate): revert to auto-review, remove post-gate bot triggers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,10 +2,12 @@
 # Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
 
 reviews:
-  # Auto-review disabled — CodeRabbit only reviews when triggered post-gate
-  # via @coderabbitai review comment from the review-gate workflow
+  # Auto-review enabled — CodeRabbit reviews on PR open as early advisory signal.
+  # Post-gate triggering via @coderabbitai review is incompatible with
+  # enabled: false (CodeRabbit treats skipped commits as "already reviewed").
+  # CRS/CE chain remains the structural blocking gate.
   auto_review:
-    enabled: false
+    enabled: true
   # Review profile: assertive = thorough, flags real issues
   profile: assertive
   # Post findings as comments only — do not block PRs with CHANGES_REQUESTED

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -251,86 +251,16 @@ jobs:
               core.setFailed(`Failed to update PR status: ${error.message}`);
             }
 
-      # AI code review bots:
-      # - CodeRabbit: auto-review DISABLED, triggered explicitly post-gate below
-      # - Cubic Dev AI: auto-reviews on PR activity (no gate control available)
-      # - Qodo: triggered via /review comment post-gate below
-      - name: Request CodeRabbit Review
-        if: always() && steps.review_check.outputs.exit_code == '0'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        with:
-          script: |
-            const prNumber = Number(process.env.PR_NUMBER);
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            const headSha = pr.head.sha;
-            const marker = `<!-- coderabbit-review-request-${headSha} -->`;
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100
-              }
-            );
-
-            if (comments.find(c => c.user.type === 'Bot' && c.body.includes(marker))) {
-              console.log(`CodeRabbit review already requested for ${headSha}, skipping`);
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `${marker}\n@coderabbitai review`
-            });
-            console.log(`Requested CodeRabbit review for ${headSha}`);
-
-      - name: Request Qodo Review
-        if: always() && steps.review_check.outputs.exit_code == '0'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        with:
-          script: |
-            const prNumber = Number(process.env.PR_NUMBER);
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            const headSha = pr.head.sha;
-            const marker = `<!-- qodo-review-request-${headSha} -->`;
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100
-              }
-            );
-
-            if (comments.find(c => c.user.type === 'Bot' && c.body.includes(marker))) {
-              console.log(`Qodo review already requested for ${headSha}, skipping`);
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `/review\n${marker}`
-            });
-            console.log(`Requested Qodo review for ${headSha}`);
+      # AI code review bots (all advisory, non-blocking):
+      # - CodeRabbit: auto-reviews on PR open/push (configured in .coderabbit.yaml)
+      # - Cubic Dev AI: auto-reviews on PR activity (no configuration available)
+      # - Qodo: auto-reviews on PR activity via GitHub App
+      #
+      # Post-gate workflow triggers were removed because:
+      # 1. CodeRabbit: enabled:false treats skipped commits as "already reviewed",
+      #    making @coderabbitai review ineffective. Re-enabled auto-review instead.
+      # 2. Qodo: /review from github-actions[bot] works intermittently (first
+      #    trigger per PR only). Auto-reviews via GitHub App are more reliable.
+      # 3. Bot-to-bot comment triggers are unreliable across all providers.
+      #
+      # The CRS/CE chain (via submit-review tool) remains the structural gate.


### PR DESCRIPTION
## Summary
- **Re-enable CodeRabbit auto-review** — post-gate triggering via `@coderabbitai review` is incompatible with `enabled: false` (CodeRabbit treats skipped commits as "already reviewed")
- **Remove post-gate bot trigger steps** — 86 lines of unreliable bot-to-bot orchestration removed
- **Simplified architecture** — all bots auto-review on PR open/push as advisory signal; CRS/CE chain remains the structural blocking gate

## Evidence (from PR #319 testing)

| Issue | Detail |
|---|---|
| CodeRabbit `enabled: false` | Marks skipped commits as "processed". `@coderabbitai review` returns "does not re-review already reviewed commits" |
| CodeRabbit trigger scope | `@coderabbitai review` is for "paused" reviews (temporary), not "disabled" (permanent config) |
| Qodo bot-to-bot | First `/review` from `github-actions[bot]` works, second on new SHA is ignored |
| Manual triggers | Human-posted `@coderabbitai review` and `/review` work consistently |

## Test plan
- [ ] Verify CodeRabbit auto-reviews on this PR (should see walkthrough + review comments)
- [ ] Verify no post-gate trigger comments are posted by the workflow
- [ ] Verify Qodo and Cubic still auto-review independently
- [ ] Verify CRS/CE gate still functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled CodeRabbit auto-review and removed post-gate comment triggers to stop missed/ignored reviews and simplify the review gate. Bots now review on PR open/push as advisory; the CRS/CE chain remains the only blocking gate.

- **Bug Fixes**
  - `@coderabbitai review` didn’t work with `enabled: false` because skipped commits were treated as already reviewed.
  - Qodo `/review` from `github-actions[bot]` was unreliable and only worked once per PR.

- **Refactors**
  - Set `auto_review.enabled: true` in `.coderabbit.yaml`.
  - Removed bot-to-bot trigger steps from `.github/workflows/review-gate.yml`.

<sup>Written for commit 9eb72e75f206b67aef5bcbeb53f835090980984b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

