### PR TITLE
refactor(skill): add TMG checkpoint to operating-discipline and build…

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/skills/build-execution/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/build-execution/SKILL.md
@@ -41,7 +41,8 @@ INTEGRATION::"Context7 for external contracts + Repomix for internal structure =
 DISCIPLINE::"See tdd-discipline pattern"
 WORKFLOW::[
   "RED: Write failing test first",
-  "GREEN: Minimal code to pass",
+  "TMG_GATE(T2+): Return to caller after RED. For T2+ tiers, TMG reviews tests via /review-red before GREEN proceeds. Do NOT implement until TMG APPROVED.",
+  "GREEN: Minimal code to pass (T2+: only after TMG approval)",
   "REFACTOR: Improve while green",
   "COMMIT: test: → feat: → refactor: pattern"
 ]

--- a/src/hestai_mcp/_bundled_hub/library/skills/operating-discipline/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/operating-discipline/SKILL.md
@@ -6,7 +6,7 @@ META:
 
 §1::OPERATING_ESSENTIALS
 PHASE_GATES::"D1(NORTH-STAR)→D2(DESIGN)→D3(BLUEPRINT)→B0(VALIDATION)→B1(BUILD-PLAN+STOP)→B2(TDD)→B3(INTEGRATION)→B4(HANDOFF)"
-QUALITY_GATES::"TDD(failing_test_first)→CodeReview(every_change)→Tests(must_pass)→Security(scan_required)"
+QUALITY_GATES::"TDD(failing_test_first)→TMG_CHECKPOINT(T2+:/review-red)→CodeReview(every_change)→Tests(must_pass)→Security(scan_required)"
 RACI_CONSULTATIONS::"critical-engineer(tactical)→principal-engineer(strategic)→security-specialist(security)→requirements-steward(alignment)→test-methodology-guardian(discipline)"
 
 §2::ENFORCEMENT_PROTOCOL
@@ -29,7 +29,7 @@ ESCALATION_CRITERIA::[
 §5::ANCHOR_KERNEL
 TARGET::enforce_operating_discipline_gates_and_boundaries
 PHASE_GATES::D1→D2→D3→B0→B1→B2→B3→B4
-QUALITY_GATES::TDD[failing_test_first]→CodeReview[every_change]→Tests[must_pass]→Security[scan_required]
+QUALITY_GATES::TDD[failing_test_first]→TMG[T2+_review-red]→CodeReview[every_change]→Tests[must_pass]→Security[scan_required]
 RACI::[CE[tactical], PE[strategic], SecSpec[security], ReqSteward[alignment], TMG[discipline]]
 BLOCKING::[production_risk, system_standard_misalignment, coherence_threats, gap_abandonment, gate_bypass, RACI_avoidance, phase_progression_without_artifacts]
 ESCALATE_TO_HUMAN::[new_principle_conflicts, authority_scope_expansion, fundamental_structure_change]


### PR DESCRIPTION
…-execution TDD workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Test Methodology Guardian checkpoint to the TDD workflow for T2+ work. Teams must pause after RED and get TMG approval via `/review-red` before GREEN.

- **Refactors**
  - Inserted `TMG_GATE(T2+)` step in `build-execution` TDD flow; updated GREEN to run only after approval.
  - Added `TMG_CHECKPOINT(T2+:/review-red)` to `operating-discipline` quality gates and `ANCHOR_KERNEL` alias (`TMG[T2+_review-red]`).

- **Migration**
  - For T2+: stop after RED and request review via `/review-red`; proceed only after TMG approves.
  - All non‑T2 work is unchanged.

<sup>Written for commit 86299ea64768ff7d1c49d085284089144d8df3cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TDD enforcement workflow to include a mandatory test review checkpoint for T2+ tier executions after the failing test stage before proceeding to implementation.
  * Enhanced quality gates sequences with a required test management review step for T2+ tiers, inserted between test execution and code review phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->