### PR TITLE
refactor(skill): change TMG checkpoint from command invocation to skill-load pattern

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/skills/build-execution/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/build-execution/SKILL.md
@@ -41,7 +41,7 @@ INTEGRATION::"Context7 for external contracts + Repomix for internal structure =
 DISCIPLINE::"See tdd-discipline pattern"
 WORKFLOW::[
   "RED: Write failing test first",
-  "TMG_GATE(T2+): Return to caller after RED. For T2+ tiers, TMG reviews tests via /review-red before GREEN proceeds. Do NOT implement until TMG APPROVED.",
+  "TMG_GATE(T2+): After RED, load review-red skill and follow its protocol. TMG must review tests before GREEN proceeds. Do NOT implement until TMG APPROVED.",
   "GREEN: Minimal code to pass (T2+: only after TMG approval)",
   "REFACTOR: Improve while green",
   "COMMIT: test: → feat: → refactor: pattern"

--- a/src/hestai_mcp/_bundled_hub/library/skills/operating-discipline/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/operating-discipline/SKILL.md
@@ -6,7 +6,7 @@ META:
 
 §1::OPERATING_ESSENTIALS
 PHASE_GATES::"D1(NORTH-STAR)→D2(DESIGN)→D3(BLUEPRINT)→B0(VALIDATION)→B1(BUILD-PLAN+STOP)→B2(TDD)→B3(INTEGRATION)→B4(HANDOFF)"
-QUALITY_GATES::"TDD(failing_test_first)→TMG_CHECKPOINT(T2+:/review-red)→CodeReview(every_change)→Tests(must_pass)→Security(scan_required)"
+QUALITY_GATES::"TDD(failing_test_first)→TMG_CHECKPOINT(T2+:load_review-red_skill)→CodeReview(every_change)→Tests(must_pass)→Security(scan_required)"
 RACI_CONSULTATIONS::"critical-engineer(tactical)→principal-engineer(strategic)→security-specialist(security)→requirements-steward(alignment)→test-methodology-guardian(discipline)"
 
 §2::ENFORCEMENT_PROTOCOL
@@ -29,7 +29,7 @@ ESCALATION_CRITERIA::[
 §5::ANCHOR_KERNEL
 TARGET::enforce_operating_discipline_gates_and_boundaries
 PHASE_GATES::D1→D2→D3→B0→B1→B2→B3→B4
-QUALITY_GATES::TDD[failing_test_first]→TMG[T2+_review-red]→CodeReview[every_change]→Tests[must_pass]→Security[scan_required]
+QUALITY_GATES::TDD[failing_test_first]→TMG[T2+_load_review-red_skill]→CodeReview[every_change]→Tests[must_pass]→Security[scan_required]
 RACI::[CE[tactical], PE[strategic], SecSpec[security], ReqSteward[alignment], TMG[discipline]]
 BLOCKING::[production_risk, system_standard_misalignment, coherence_threats, gap_abandonment, gate_bypass, RACI_avoidance, phase_progression_without_artifacts]
 ESCALATE_TO_HUMAN::[new_principle_conflicts, authority_scope_expansion, fundamental_structure_change]


### PR DESCRIPTION
## Summary
- Changed TMG checkpoint references in `build-execution` and `operating-discipline` skills from `/review-red` command invocation to "load review-red skill and follow its protocol"
- This eliminates indirection: IL absorbs and executes the review-red protocol inline rather than invoking it as an external slash command
- Aligns with how agents consume skills during governed workflows

## Files Changed
- `src/hestai_mcp/_bundled_hub/library/skills/build-execution/SKILL.md` — §3 TDD workflow TMG_GATE step
- `src/hestai_mcp/_bundled_hub/library/skills/operating-discipline/SKILL.md` — §1 QUALITY_GATES + §5 ANCHOR_KERNEL

## Test plan
- [ ] Verify MCP server restart delivers updated skills to `.hestai-sys/`
- [ ] Verify anchor ceremony loads updated skill kernels with new TMG reference
- [ ] Confirm IL TDD workflow correctly references skill-load pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch TMG checkpoint from invoking `/review-red` to loading the review-red skill inline in the `build-execution` and `operating-discipline` skills. This removes indirection and ensures IL runs the review protocol before GREEN in governed workflows.

<sup>Written for commit ee13a7045dc22d3dcba2f1a505625aa3314f14b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Updated build execution workflow documentation to reflect refined T2+ gate review procedures, enhancing operational efficiency
- Enhanced operating discipline quality gate sequences to align with the updated review protocol
- Reviewed and refined quality checkpoints across multiple workflow stages for improved clarity
- All existing quality assurance, security, and approval standards remain fully operational

<!-- end of auto-generated comment: release notes by coderabbit.ai -->