### PR TITLE
fix: review-preflight delegation via pal_chat, not Task subagent

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/skills/review-preflight/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/review-preflight/SKILL.md
@@ -1,9 +1,9 @@
 ===SKILL:REVIEW_PREFLIGHT===
 META:
   TYPE::SKILL
-  VERSION::"1.0.0"
+  VERSION::"1.1.0"
   STATUS::ACTIVE
-  PURPOSE::"Mechanical prep delegation before review. Collects structured context brief via subagent so CRS spends tokens on judgement, not grunt work."
+  PURPOSE::"Mechanical prep delegation before review. Collects structured context brief via pal_chat so CRS spends tokens on judgement, not grunt work."
 
 §1::CORE
 AUTHORITY::ADVISORY[preflight_brief_structure]
@@ -11,7 +11,8 @@ PHASE::PRE_REVIEW[runs_BEFORE_review-discipline⊕review-prioritization]
 COMPLEMENTS::[review-discipline<confidence>,review-prioritization<triage>]
 
 §2::PROTOCOL
-// CRS delegates preflight collection to a lightweight subagent
+// CRS delegates preflight collection via mcp__pal__chat
+// CRS runs as subagent (no Task tool) — PAL MCP tools are the delegation path
 DETECT_CONTEXT::[
   PR::"gh_pr_view→has_diff⊕has_CI⊕has_tier",
   STANDALONE::"file_list_provided→no_PR_metadata",
@@ -29,20 +30,20 @@ OUTPUT::STRUCTURED_BRIEF[consumed_by_CRS_before_review_begins]
 
 §3::GOVERNANCE
 DELEGATION::[
-  SPAWN::lightweight_subagent_for_mechanical_collection,
+  TOOL::mcp__pal__chat[or_mcp__pal__clink_for_CLI_providers],
   PROVIDER_AGNOSTIC::no_model_specification[runtime_selects],
-  TOOLS::gh_CLI⊕file_search⊕grep[available_to_subagent]
+  FILE_PATHS::pass_absolute_file_paths_parameter[not_inline_code]
 ]
 BUDGET::[
   BRIEF_ONLY::collect_facts_not_judgements,
-  NO_REVIEW::subagent_NEVER_evaluates_code_quality,
+  NO_REVIEW::delegate_NEVER_evaluates_code_quality,
   CONCISE::brief_fits_in_500_tokens_max
 ]
 
 §5::ANCHOR_KERNEL
 TARGET::structured_preflight_brief_before_review
 NEVER::[evaluate_code_quality_in_preflight,specify_model_or_provider,skip_context_detection,produce_findings_or_verdicts]
-MUST::[detect_review_context_type,collect_file_summary_and_languages,map_security_sensitive_paths,map_changed_files_to_tests,delegate_to_subagent]
-GATE::"Is a structured preflight brief collected via delegation before CRS begins review judgement?"
+MUST::[detect_review_context_type,collect_file_summary_and_languages,map_security_sensitive_paths,map_changed_files_to_tests,delegate_via_pal_tools]
+GATE::"Is a structured preflight brief collected via PAL delegation before CRS begins review judgement?"
 
 ===END===


### PR DESCRIPTION
## Summary

- Fixes review-preflight skill to use `mcp__pal__chat` / `mcp__pal__clink` instead of Task subagent spawning

## Context

CRS runs as a subagent via oa-router and has no access to the Task tool. The review-preflight skill (merged in #350) incorrectly instructed CRS to "spawn a lightweight subagent" — which is impossible from inside a subagent.

PAL MCP tools (`mcp__pal__chat`, `mcp__pal__clink`) are available to all agents regardless of nesting depth and are the correct delegation path.

## Changes

- `SPAWN::lightweight_subagent` → `TOOL::mcp__pal__chat[or_mcp__pal__clink_for_CLI_providers]`
- Added comment explaining why: subagents don't have Task tool
- `delegate_to_subagent` → `delegate_via_pal_tools` in anchor kernel
- VERSION 1.0.0 → 1.1.0

## Test plan

- [x] OCTAVE validation passes (pre-commit)
- [x] T1 self-review (17 lines, single file)
- [ ] Verify CRS can invoke pal_chat during preflight when running as subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the review-preflight skill to delegate via `mcp__pal__chat`/`mcp__pal__clink` instead of spawning a `Task` subagent. This unblocks preflight when CRS runs as a subagent.

- **Bug Fixes**
  - Delegate via `mcp__pal__chat`/`mcp__pal__clink` instead of a `Task` subagent.
  - Update anchor kernel and notes to reflect PAL delegation (GATE, PURPOSE, governance).
  - Bump version to 1.1.0.

<sup>Written for commit 9e743c1445fa75dfe466d38c13607df001883416. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Review Preflight skill to version 1.1.0 with refinements to delegation handling and configuration governance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->