### PR TITLE
chore: upgrade octave-mcp to v1.9.6

### DIFF
--- a/.hestai/rules/octave-integration-guide.oct.md
+++ b/.hestai/rules/octave-integration-guide.oct.md
@@ -8,14 +8,14 @@ META:
   DOMAIN::workflow
   OWNERS::[system-steward]
   CREATED::"2025 -12 -21"
-  UPDATED::"2026-03-08"
+  UPDATED::"2026-03-30"
   CANONICAL::".hestai/rules/octave-integration-guide.oct.md"
   TAGS::[
     octave,
     internal,
     hestai-mcp
   ]
-  OCTAVE_VERSION::"1.9.1"
+  OCTAVE_VERSION::"1.9.6"
 ---
 // This file is HestAI-MCP INTERNAL documentation.
 // Consumer-facing OCTAVE guide: .hestai-sys/library/octave/octave-usage-guide.oct.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "keyring>=24.0.0",
     "pyyaml>=6.0",
-    "octave-mcp>=1.9.5",  # Official OCTAVE parser with GBNF export and holographic contracts
+    "octave-mcp>=1.9.6",  # Official OCTAVE parser with GBNF export and holographic contracts
 ]
 
 [project.optional-dependencies]

--- a/src/hestai_mcp/_bundled_hub/standards/HESTAI-ECOSYSTEM-DEPENDENCY-GRAPH.oct.md
+++ b/src/hestai_mcp/_bundled_hub/standards/HESTAI-ECOSYSTEM-DEPENDENCY-GRAPH.oct.md
@@ -5,7 +5,7 @@ META:
   STATUS::TARGET
   PURPOSE::"Cross-system build sequence, blocking relationships, and phase alignment"
   CREATED::"2026-02-22"
-  REVISED::"2026-03-28"
+  REVISED::"2026-03-30"
   FORMAT::octave
   RESOLVES::"#265 (Cross-repo ecosystem dependency graph)"
   SUPPLEMENTS::HESTAI-ECOSYSTEM-OVERVIEW.oct.md
@@ -15,7 +15,7 @@ ARCHITECTURE_DECISION::"Federation model (v2.1) replaced by Thick Client model (
 CURRENT_REALITY::"Until workbench migration is complete, the current federation (hestai-mcp + odyssean-anchor-mcp as separate MCP servers) remains operational. This graph describes the approved build sequence toward the target state."
 §1::CURRENT_STATE
 OCTAVE_MCP::[
-  VERSION::"1.9.2",
+  VERSION::"1.9.6",
   PHASE::B5_DOCUMENTATION,
   HEALTH::PRODUCTION_READY,
   PYPI::published,
@@ -85,7 +85,7 @@ ARROWS::[
   "workbench --[absorbing]--> odyssean-anchor-mcp (anchor ceremony rebuild in TypeScript)"
 ]
 §3::LAYER_MODEL_WITH_STATE
-LAYER_0::"FOUNDATION — octave-mcp: SOLID, v1.9.2, production. ACTION: Update deps when releases happen. No structural changes needed."
+LAYER_0::"FOUNDATION — octave-mcp: SOLID, v1.9.6, production. ACTION: Update deps when releases happen. No structural changes needed."
 LAYER_1::"DELIBERATION — debate-hall-mcp: SOLID, v0.5.0, production, 17 tools. ACTION: Continue independently. Issue 163 (Governance Hall), Issue 159 (RACI mode)."
 LAYER_2::"UNIFIED_PLATFORM — hestai-workbench: PROTOTYPE, Phase_2_complete, absorbing hestai-mcp and OA. ACTION: Build Engine + Glass + Library Manager. Critical path for entire ecosystem."
 §4::SEQUENCED_BUILD_ORDER

--- a/src/hestai_mcp/_bundled_hub/standards/HESTAI-ECOSYSTEM-OVERVIEW.oct.md
+++ b/src/hestai_mcp/_bundled_hub/standards/HESTAI-ECOSYSTEM-OVERVIEW.oct.md
@@ -6,7 +6,7 @@ META:
   PURPOSE::"How every system in the HestAI ecosystem connects and what each owns"
   CANONICAL::"src/hestai_mcp/_bundled_hub/standards/HESTAI-ECOSYSTEM-OVERVIEW.oct.md"
   CREATED::"2026-02-18"
-  REVISED::"2026-03-28"
+  REVISED::"2026-03-30"
   FORMAT::octave
 §0::ARCHITECTURE_NOTE
 DESCRIPTION::"This document describes the APPROVED TARGET three-system Thick Client architecture. The workbench will absorb hestai-mcp and odyssean-anchor-mcp into a unified platform (Engine + Glass + Library). debate-hall-mcp and octave-mcp remain standalone. See docs/dream-team-architecture.md for the specification."
@@ -27,7 +27,7 @@ ECOSYSTEM::"Three target systems that together will provide agent identity, gove
 §2::THE_THREE_SYSTEMS
 SYSTEM_1::"HESTAI_WORKBENCH[REPO::elevanaltd/hestai-workbench, ROLE::The Unified Platform, OWNS::[agent_definitions, skills_library, anchor_ceremony, context_steward, session_lifecycle, governance_rules, agent_registry, worktree_orchestration, cli_spawning, terminal_ui, agent_dispatch, payload_compilation, pipeline_runner], ABSORBS::[hestai-mcp(library+governance+session_lifecycle), odyssean-anchor-mcp(anchor_ceremony+identity_binding)], ARCHITECTURE::Engine (Node/TS backend with payload compiler + dispatcher + pipeline runner + anchor validator) + Glass (React frontend with agent registry + session dashboard + workflow editor + dispatch chain visibility) + Library Manager (reads/writes .hestai-sys/ and .hestai/ directly), KEY_PROPERTY::Unified center. Knows WHO agents are, HOW they behave, WHICH provider runs them, WHERE sessions run. Single process, single debug target., DEPENDS_ON::[debate-hall-mcp, octave-mcp], DATA::[~/.hestai-workbench/library/ (agent definitions, skills, standards — canonical after migration Step 2), SQLite database (sessions, agent registry, UI state), git worktrees per session, .hestai-sys/ (written to worktrees at spawn — same pattern, workbench is writer), .hestai/ (project context, committed, read by workbench), .hestai/state/ (working state, written by workbench)]]"
 SYSTEM_2::"DEBATE_HALL_MCP[REPO::elevanaltd/debate-hall-mcp, ROLE::The Deliberation Chamber, VERSION::0.5.0, OWNS::[wind_wall_door_debates, governance_operations, decision_records, hash_chain_integrity], TOOLS::17, KEY_PROPERTY::Standalone deliberation (P6). Works without HestAI for non-governance users. Persistent transcripts with hash-chain integrity., DEPENDS_ON::[octave-mcp], DATA::[debates/ directory with JSON state, OCTAVE-compressed transcripts, decision records with SHA-256 hash chain]]"
-SYSTEM_3::"OCTAVE_MCP[REPO::elevanaltd/octave-mcp, ROLE::The Language, VERSION::1.9.2, OWNS::[octave_format_spec, validation, generation, compression], TOOLS::[octave_validate, octave_write, octave_eject], KEY_PROPERTY::Pure protocol. Zero dependencies on governance. Maximum community adoption potential. 54-68 percent token reduction., DEPENDS_ON::[nothing], DATA::[v6 grammar specification, GHC (Generative Holographic Contracts)]]"
+SYSTEM_3::"OCTAVE_MCP[REPO::elevanaltd/octave-mcp, ROLE::The Language, VERSION::1.9.6, OWNS::[octave_format_spec, validation, generation, compression], TOOLS::[octave_validate, octave_write, octave_eject], KEY_PROPERTY::Pure protocol. Zero dependencies on governance. Maximum community adoption potential. 54-68 percent token reduction., DEPENDS_ON::[nothing], DATA::[v6 grammar specification, GHC (Generative Holographic Contracts)]]"
 §3::SYSTEMS_BEING_ABSORBED
 CANONICAL_SOURCE_DURING_MIGRATION::"During migration, hestai-mcp repository remains the source-of-truth for library content (agents, skills, standards, cognitions). After workbench Library Manager (dependency graph Step 2) is complete and verified, canonical source moves to workbench library. Both repos must not diverge during this period."
 HESTAI_MCP_ABSORPTION::[
@@ -106,7 +106,7 @@ DEBATE_HALL_STATUS::[
   NEXT::"Continue at own pace. Issue 163 (Governance Hall), Issue 159 (RACI mode). Independent of workbench migration."
 ]
 OCTAVE_STATUS::[
-  STATUS::"operational, v1.9.2, PyPI published",
+  STATUS::"operational, v1.9.6, PyPI published",
   NEXT::"Standalone community adoption. Chassis-Profile grammar RFC. No governance dependencies."
 ]
 HESTAI_MCP_STATUS::[

--- a/tests/unit/governance/test_octave_mcp_compat.py
+++ b/tests/unit/governance/test_octave_mcp_compat.py
@@ -1,4 +1,4 @@
-"""Smoke tests for octave-mcp 1.9.5 compatibility.
+"""Smoke tests for octave-mcp 1.9.6 compatibility.
 
 Verifies the octave-mcp package is importable and its core APIs
 work with HestAI's usage patterns.
@@ -11,7 +11,7 @@ pytest.importorskip("octave_mcp", reason="octave-mcp not installed")
 
 @pytest.mark.smoke
 class TestOctaveMcpCompat:
-    """Verify octave-mcp 1.9.5 compatibility with HestAI imports."""
+    """Verify octave-mcp 1.9.6 compatibility with HestAI imports."""
 
     @pytest.mark.unit
     def test_core_imports(self):
@@ -37,8 +37,8 @@ class TestOctaveMcpCompat:
         numeric_parts = re.findall(r"\d+", version.split("+")[0].split("-")[0])
         parts = [int(x) for x in numeric_parts[:3]]
         parts.extend([0] * (3 - len(parts)))  # Pad missing minor/patch
-        # Must be >= 1.9.5
-        assert tuple(parts) >= (1, 9, 5)
+        # Must be >= 1.9.6
+        assert tuple(parts) >= (1, 9, 6)
 
     @pytest.mark.unit
     def test_parse_simple_document(self):

--- a/uv.lock
+++ b/uv.lock
@@ -383,7 +383,7 @@ requires-dist = [
     { name = "keyring", specifier = ">=24.0.0" },
     { name = "mcp", specifier = ">=0.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "octave-mcp", specifier = ">=1.9.5" },
+    { name = "octave-mcp", specifier = ">=1.9.6" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.9.5"
+version = "1.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -718,9 +718,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/0a/cf3cd1f6c8aac10b8c66ed8115c1bf63990e6c96b85b26ae6c0ffd38ad47/octave_mcp-1.9.5.tar.gz", hash = "sha256:5c6ca211736617e76306c28f9aa491379d29eb2d56c6d8923365f4186851ac14", size = 255587, upload-time = "2026-03-26T08:26:17.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/2d/4c4bca62db72e7cdb37b376fe536ab0b762a88e87fd89d8b3df3c591c02c/octave_mcp-1.9.6.tar.gz", hash = "sha256:0fab14b4b1b54f7c8dc5ba5314383b5099dbed1aab4f0a8c06bb083936e5b839", size = 256001, upload-time = "2026-03-30T11:02:14.946Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/a8/d7d00cf89ff312ed8a1734616a8a737f34eb0f029470602293bb35260398/octave_mcp-1.9.5-py3-none-any.whl", hash = "sha256:1a43440a6c998207b078eb7de863b2d7e0ff102106938bc67ef039a6fb1de6b4", size = 274348, upload-time = "2026-03-26T08:26:15.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b7/b3d3681d641ab1dac9e54060a74eb4cb42c5ffb7644426896703070b3de9/octave_mcp-1.9.6-py3-none-any.whl", hash = "sha256:0fd0d6c200cea75f0527afcd429aea6f347474a561f22b2bdab7413a87d1a7be", size = 274998, upload-time = "2026-03-30T11:02:13.084Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `octave-mcp` dependency from `>=1.9.5` to `>=1.9.6` in `pyproject.toml`
- Update `uv.lock` (pinned 1.9.5 → 1.9.6)
- Update `test_octave_mcp_compat.py` minimum version assertion to `(1, 9, 6)`
- Update `OCTAVE_VERSION` reference in `.hestai/rules/octave-integration-guide.oct.md`
- Update octave-mcp version references (1.9.2 → 1.9.6) in ecosystem standards docs

## Test plan

- [x] `uv sync` installs octave-mcp 1.9.6
- [x] Smoke tests pass (`pytest -m smoke`) — all 4 compat tests green
- [x] Ruff, black, mypy all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `octave-mcp` to v1.9.6 to use the latest language updates and keep tooling, docs, and tests aligned. Updates `pyproject.toml` and `uv.lock`, refreshes version references in ecosystem/integration docs, and raises the compatibility test floor to 1.9.6.

<sup>Written for commit a5fefa6aea9b79c780e68744e43c8822ecdcec90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated minimum dependency version requirement to 1.9.6
  * Updated documentation and metadata to reflect dependency version changes

* **Tests**
  * Updated version compatibility checks to align with new requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->