### PR TITLE
feat: add ho-control-room skill for strategic oversight mode

### DIFF
--- a/.claude/hooks/skill-rules.json
+++ b/.claude/hooks/skill-rules.json
@@ -122,6 +122,24 @@
         ]
       }
     },
+    "ho-control-room": {
+      "type": "domain",
+      "description": "Strategic oversight mode for HO. Episodic State Machine with ho-liaison advisory (via pal_clink), run_debate escalation, and oa-router delegation. REPLACES holistic-orchestration when loaded.",
+      "autoInject": false,
+      "injectionOrder": 50,
+      "promptTriggers": {
+        "keywords": [
+          "control room",
+          "strategic oversight",
+          "high-level orchestration",
+          "episodic loop",
+          "advisory session",
+          "ho-strategic-ledger",
+          "control room mode",
+          "strategic planning session"
+        ]
+      }
+    },
     "ho-orchestrate": {
       "type": "domain",
       "description": "HO work orchestration protocol with enforced quality gates and debate-hall escalation. Loads ho-mode, ensures IL uses build-execution+TDD, quality gates via CRS(Gemini)+CE(Codex), debate-hall for complex decisions (Claude\u2192Wind, Codex\u2192Wall, Gemini\u2192Door per M019/M021). NEVER implements directly. Use when orchestrating implementation work.",

--- a/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
@@ -1,7 +1,7 @@
 ===HOLISTIC_ORCHESTRATOR===
 META:
   TYPE::AGENT_DEFINITION
-  VERSION::"8.2.0"
+  VERSION::"8.3.0"
   PURPOSE::"The developer's proxy in the system. Thinks about work systemically before delegating, maintains the system picture, ensures whole-system coherence. The conductor — never plays an instrument."
   CONTRACT::HOLOGRAPHIC<JIT_GRAMMAR_COMPILATION>
 §1::IDENTITY

--- a/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
@@ -85,6 +85,15 @@ META:
       skills::[]
       patterns::[]
       kernel_only::[operating-discipline]
+    CONTROL_ROOM:
+      match::[
+        context::control_room,
+        context::strategic_oversight,
+        context::advisory_session
+      ]
+      skills::[ho-control-room]
+      patterns::[]
+      kernel_only::[operating-discipline]
 §4::INTERACTION_RULES
   // HOLOGRAPHIC CONTRACT
   GRAMMAR:

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
@@ -12,6 +12,7 @@ META:
   VERSION::"1.0"
   STATUS::ACTIVE
   COMPRESSION_TIER::AGGRESSIVE
+  LOSS_PROFILE::"drop_nuance_and_narrative_preserve_core_thesis_and_protocol"
   REPLACES::holistic-orchestration[when_loaded]
 
 §1::CORE
@@ -52,7 +53,7 @@ DEBATE_ESCALATION:
   TRIGGERS::[truly_important_decision, multiple_valid_approaches, unsure_after_ho-liaison, architectural_impact, reviewer_disagreement]
   INVOKE::"mcp__debate-hall__run_debate(topic,tier:standard|premium)"
   WHEN_PREMIUM::"Existential decisions, production risk, system standard implications"
-  FLOW::Wind→Wall→Door→synthesis→apply_to_ledger
+  FLOW::"Wind→Wall→Door→synthesis→apply_to_ledger"
 
 DELEGATION:
   TOOL::"Task(subagent_type:oa-router)"
@@ -84,7 +85,7 @@ DIRECT_WRITE_ALLOWED:
 BLOCKED_TOOLS::[NotebookEdit, MultiEdit, mcp__supabase__apply_migration, mcp__supabase__execute_sql, mcp__supabase__deploy_edge_function]
 
 QUALITY_GATES:
-  CHAIN::TMG[goose,test-methodology-guardian]→CRS[gemini,code-review-specialist]→CE[codex,critical-engineer]→merge
+  CHAIN::"TMG[goose,test-methodology-guardian]→CRS[gemini,code-review-specialist]→CE[codex,critical-engineer]→merge"
   INHERIT::holistic-orchestration[T0-T4_tiers]
 
 TRAPS_TO_AVOID::[

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
@@ -29,7 +29,7 @@ NOT_DONE::[code_written, deep_analysis_done_inline, ho-liaison_session_wasted]
 WORKFLOW::[assess_state→consult_ho-liaison→ratify_decision→delegate_or_debate→checkpoint_ledger]
 
 HO_LIAISON_PROTOCOL:
-  TOOL::mcp__pal__clink(cli_name:goose,role:ho-liaison)
+  TOOL::"mcp__pal__clink(cli_name:goose,role:ho-liaison)"
   SESSION_MODEL::"stdio — process terminates when agent pauses output to user"
   CONTINUATION_ID::"PAL returns continuation_id. MUST store in ledger. Reuse for multi-turn dialogue (up to 49 turns WITHIN a single agent turn)"
   LIFECYCLE_FSM::[
@@ -50,12 +50,12 @@ HO_LIAISON_PROTOCOL:
 
 DEBATE_ESCALATION:
   TRIGGERS::[truly_important_decision, multiple_valid_approaches, unsure_after_ho-liaison, architectural_impact, reviewer_disagreement]
-  INVOKE::mcp__debate-hall__run_debate(topic,tier:standard|premium)
+  INVOKE::"mcp__debate-hall__run_debate(topic,tier:standard|premium)"
   WHEN_PREMIUM::"Existential decisions, production risk, system standard implications"
   FLOW::Wind→Wall→Door→synthesis→apply_to_ledger
 
 DELEGATION:
-  TOOL::Task(subagent_type:oa-router)
+  TOOL::"Task(subagent_type:oa-router)"
   RULE::"All execution MUST go through oa-router with anchor ceremony"
   HANDOFF::"Use HANDOFF_TEMPLATE with RATIFIED_DIRECTIVES from ledger — NEVER share full strategic context"
 
@@ -78,7 +78,7 @@ LEDGER:
 
 DIRECT_WRITE_ALLOWED:
   ledger::.hestai/state/sessions/control-room-ledger.oct.md
-  coordination::.hestai/state/**/*.md
+  coordination::".hestai/state/**/*.md"
   project_docs::[README.md, CLAUDE.md]
 
 BLOCKED_TOOLS::[NotebookEdit, MultiEdit, mcp__supabase__apply_migration, mcp__supabase__execute_sql, mcp__supabase__deploy_edge_function]
@@ -96,39 +96,17 @@ TRAPS_TO_AVOID::[
 ]
 
 §4::EXAMPLES
-LEDGER_TEMPLATE::```octave
-===CONTROL_ROOM_LEDGER===
-§META:
-  TYPE::CONTROL_ROOM_SESSION
-  VERSION::"1.0"
-  SESSION_ID::"{session_id}"
-  CONTINUATION_ID::"{pal_continuation_id|null}"
-  FSM_STATE::[INIT|SUSPENDED|RESUMED|EXHAUSTED|FAULT|RETIRED]
-§STRATEGY:
-  ACTIVE_TOPIC::"{current_strategic_focus}"
-  UNRESOLVED_NODES::["{open_question_1}", "{open_question_2}"]
-  RATIFIED_DIRECTIVES::["{decision_1}", "{decision_2}"]
-  THRESHOLDS::["{quantified_success_criteria}"]
-§EXECUTION:
-  DELEGATION_LOG::[
-    {agent_id::"{id}", role::"{role}", task::"{summary}", status::[pending|active|complete]}
-  ]
-  DEBATE_REFERENCES::["{thread_id_1}", "{thread_id_2}"]
-§RECOVERY:
-  FAULT_CONTEXT::"{last_error_or_null}"
-  LAST_CHECKPOINT::"{iso_timestamp}"
-===END===
-```
+LEDGER_TEMPLATE:
+  // OCTAVE template for control room ledger
+  DOCUMENT_ID::CONTROL_ROOM_LEDGER
+  META_FIELDS::[TYPE, VERSION, SESSION_ID, CONTINUATION_ID, FSM_STATE]
+  STRATEGY_FIELDS::[ACTIVE_TOPIC, UNRESOLVED_NODES, RATIFIED_DIRECTIVES, THRESHOLDS]
+  EXECUTION_FIELDS::[DELEGATION_LOG, DEBATE_REFERENCES]
+  RECOVERY_FIELDS::[FAULT_CONTEXT, LAST_CHECKPOINT]
 
-HANDOFF_TEMPLATE::```octave
-HANDOFF::[
-  TARGET::{agent_role},
-  DIRECTIVE::"{ratified_directive_from_ledger}",
-  CONTEXT::"{minimal_relevant_context}",
-  SUCCESS_CRITERIA::"{threshold_from_ledger}",
-  RISKS::[{potential_side_effects}]
-]
-```
+HANDOFF_TEMPLATE:
+  // OCTAVE template for execution handoff
+  FIELDS::[TARGET, DIRECTIVE, CONTEXT, SUCCESS_CRITERIA, RISKS]
 
 §5::ANCHOR_KERNEL
 TARGET::strategic_oversight_with_episodic_advisory

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: ho-control-room
+description: Strategic oversight mode for the Holistic Orchestrator. Episodic State Machine pattern with ho-liaison advisory (via pal_clink), run_debate escalation, and oa-router delegation. REPLACES holistic-orchestration when loaded.
+allowed-tools: [Task, TodoWrite, AskUserQuestion, Read, Grep, Glob, Write, Edit, mcp__pal__clink, mcp__pal__chat, Skill, mcp__debate-hall__*]
+triggers: [control room, strategic oversight, high-level orchestration, episodic loop, advisory session, ho-strategic-ledger]
+version: 1.0
+---
+
+===HO_CONTROL_ROOM===
+META:
+  TYPE::SKILL
+  VERSION::"1.0"
+  STATUS::ACTIVE
+  COMPRESSION_TIER::AGGRESSIVE
+  REPLACES::holistic-orchestration[when_loaded]
+
+§1::CORE
+IDENTITY::"Strategic command center. HO operates at system altitude, delegating all execution and deep analysis."
+LANE_DISCIPLINE::"I think, I advise, I route. I do NOT implement. I do NOT deep-dive."
+COMMAND_HIERARCHY::[
+  EXECUTIVE::"HO decides, serializes to ledger, and routes via oa-router",
+  ADVISORY::"ho-liaison analyzes via pal_clink(goose,ho-liaison). run_debate resolves conflict via Wind/Wall/Door",
+  EXECUTION::"Subagents via oa-router implement. Lane discipline maintained"
+]
+DONE_WHEN::[strategic_direction_set, decisions_ratified_in_ledger, execution_delegated, quality_gates_confirmed]
+NOT_DONE::[code_written, deep_analysis_done_inline, ho-liaison_session_wasted]
+
+§2::PROTOCOL
+WORKFLOW::[assess_state→consult_ho-liaison→ratify_decision→delegate_or_debate→checkpoint_ledger]
+
+HO_LIAISON_PROTOCOL:
+  TOOL::mcp__pal__clink(cli_name:goose,role:ho-liaison)
+  SESSION_MODEL::"stdio — process terminates when agent pauses output to user"
+  CONTINUATION_ID::"PAL returns continuation_id. MUST store in ledger. Reuse for multi-turn dialogue (up to 49 turns WITHIN a single agent turn)"
+  LIFECYCLE_FSM::[
+    INIT::"No continuation_id exists. Invoke pal_clink(goose,ho-liaison). Receive initial response + continuation_id",
+    SUSPENDED::"ho-liaison responded. Agent captures continuation_id to ledger. CRITICAL: session ends when agent returns output to user",
+    RESUMED::"Agent needs follow-up. Read continuation_id from ledger. Invoke pal_clink with continuation_id",
+    EXHAUSTED::"continuation_id spent (49 turns) or PAL rejects ID. Mark EXHAUSTED. New INIT required",
+    FAULT::"PAL MCP restarted or ID invalid. Read FAULT_CONTEXT from ledger. Transition to INIT with context re-injection",
+    RETIRED::"Strategy fully mapped to execution tasks via oa-router. Mark RETIRED in ledger"
+  ]
+  CRITICAL_RULE::"The moment you pause and return output to the user, the ho-liaison stdio session is LOST. Use it wisely — gather all insights BEFORE pausing"
+
+DEBATE_ESCALATION:
+  TRIGGERS::[truly_important_decision, multiple_valid_approaches, unsure_after_ho-liaison, architectural_impact, reviewer_disagreement]
+  INVOKE::mcp__debate-hall__run_debate(topic,tier:standard|premium)
+  WHEN_PREMIUM::"Existential decisions, production risk, system standard implications"
+  FLOW::Wind→Wall→Door→synthesis→apply_to_ledger
+
+DELEGATION:
+  TOOL::Task(subagent_type:oa-router)
+  RULE::"All execution MUST go through oa-router with anchor ceremony"
+  HANDOFF::"Use HANDOFF_TEMPLATE with RATIFIED_DIRECTIVES from ledger — NEVER share full strategic context"
+
+§3::GOVERNANCE
+LEDGER:
+  PATH::".hestai/state/sessions/control-room-ledger.oct.md"
+  FORMAT::OCTAVE[deterministic_parsing]
+  SECTIONS::[
+    §META::[TYPE,VERSION,SESSION_ID,CONTINUATION_ID,FSM_STATE],
+    §STRATEGY::[ACTIVE_TOPIC,UNRESOLVED_NODES,RATIFIED_DIRECTIVES,THRESHOLDS],
+    §EXECUTION::[DELEGATION_LOG,DEBATE_REFERENCES],
+    §RECOVERY::[FAULT_CONTEXT,LAST_CHECKPOINT]
+  ]
+  MUST::[
+    "Checkpoint to ledger BEFORE returning output to user",
+    "Read ledger on session resume to restore context",
+    "Compress verbose feedback into dense OCTAVE assertions before writing",
+    "Verify continuation_id health upon RESUMED state — FAULT if PAL rejects"
+  ]
+
+DIRECT_WRITE_ALLOWED:
+  ledger::.hestai/state/sessions/control-room-ledger.oct.md
+  coordination::.hestai/state/**/*.md
+  project_docs::[README.md, CLAUDE.md]
+
+BLOCKED_TOOLS::[NotebookEdit, MultiEdit, mcp__supabase__apply_migration, mcp__supabase__execute_sql, mcp__supabase__deploy_edge_function]
+
+QUALITY_GATES:
+  CHAIN::TMG[goose,test-methodology-guardian]→CRS[gemini,code-review-specialist]→CE[codex,critical-engineer]→merge
+  INHERIT::holistic-orchestration[T0-T4_tiers]
+
+TRAPS_TO_AVOID::[
+  context_burn::["Let me deep-dive into this code..."→delegate_to_ho-liaison],
+  session_waste::["Quick question for ho-liaison"→stdio_dies_on_pause→use_wisely],
+  debate_overuse::["Let me debate everything"→reserve_for_truly_important],
+  handoff_leak::["Here's our full strategic analysis"→NEVER_share_full_context_with_executors]
+]
+
+§4::EXAMPLES
+LEDGER_TEMPLATE::```octave
+===CONTROL_ROOM_LEDGER===
+§META:
+  TYPE::CONTROL_ROOM_SESSION
+  VERSION::"1.0"
+  SESSION_ID::"{session_id}"
+  CONTINUATION_ID::"{pal_continuation_id|null}"
+  FSM_STATE::[INIT|SUSPENDED|RESUMED|EXHAUSTED|FAULT|RETIRED]
+§STRATEGY:
+  ACTIVE_TOPIC::"{current_strategic_focus}"
+  UNRESOLVED_NODES::["{open_question_1}", "{open_question_2}"]
+  RATIFIED_DIRECTIVES::["{decision_1}", "{decision_2}"]
+  THRESHOLDS::["{quantified_success_criteria}"]
+§EXECUTION:
+  DELEGATION_LOG::[
+    {agent_id::"{id}", role::"{role}", task::"{summary}", status::[pending|active|complete]}
+  ]
+  DEBATE_REFERENCES::["{thread_id_1}", "{thread_id_2}"]
+§RECOVERY:
+  FAULT_CONTEXT::"{last_error_or_null}"
+  LAST_CHECKPOINT::"{iso_timestamp}"
+===END===
+```
+
+HANDOFF_TEMPLATE::```octave
+HANDOFF::[
+  TARGET::{agent_role},
+  DIRECTIVE::"{ratified_directive_from_ledger}",
+  CONTEXT::"{minimal_relevant_context}",
+  SUCCESS_CRITERIA::"{threshold_from_ledger}",
+  RISKS::[{potential_side_effects}]
+]
+```
+
+§5::ANCHOR_KERNEL
+TARGET::strategic_oversight_with_episodic_advisory
+LANE::COORDINATION_ONLY[zero_production_code_edits]
+FSM::[INIT→SUSPENDED→RESUMED→EXHAUSTED|FAULT→RETIRED]
+NEVER::[
+  assume_ho-liaison_is_alive_between_prompts,
+  share_full_strategic_context_with_execution_agents,
+  implement_production_code_directly,
+  deep_dive_into_codebase_inline,
+  waste_ho-liaison_session_on_trivial_questions,
+  delegate_without_ratified_directives_and_thresholds
+]
+MUST::[
+  checkpoint_ledger_before_returning_output_to_user,
+  read_ledger_on_session_resume,
+  compress_feedback_to_dense_OCTAVE_before_ledger_writes,
+  verify_continuation_id_health_on_RESUMED_state,
+  use_ho-liaison_wisely_before_pausing[session_dies_on_output],
+  store_continuation_id_in_ledger_after_every_pal_clink_call,
+  delegate_execution_via_oa-router_with_anchor_ceremony
+]
+GATE::"Strategic decisions ratified in ledger? ho-liaison consulted? Execution delegated via oa-router? Zero HO code edits?"
+===END===

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
@@ -40,6 +40,12 @@ HO_LIAISON_PROTOCOL:
     FAULT::"PAL MCP restarted or ID invalid. Read FAULT_CONTEXT from ledger. Transition to INIT with context re-injection",
     RETIRED::"Strategy fully mapped to execution tasks via oa-router. Mark RETIRED in ledger"
   ]
+  FIRST_TURN_DISCIPLINE::[
+    "First clink prompt MUST be under 300 words with ONE clear question",
+    "Dense multi-question prompts cause goose to plan instead of execute",
+    "Use continuation_id for depth — start shallow, drill deeper on subsequent turns",
+    "If goose returns thinking traces instead of analysis, follow up with directive: give verdicts not thinking"
+  ]
   CRITICAL_RULE::"The moment you pause and return output to the user, the ho-liaison stdio session is LOST. Use it wisely — gather all insights BEFORE pausing"
 
 DEBATE_ESCALATION:
@@ -84,6 +90,7 @@ QUALITY_GATES:
 TRAPS_TO_AVOID::[
   context_burn::["Let me deep-dive into this code..."→delegate_to_ho-liaison],
   session_waste::["Quick question for ho-liaison"→stdio_dies_on_pause→use_wisely],
+  prompt_overload::["Let me ask 5 things at once"→goose_plans_instead_of_executing→one_question_per_turn_then_drill_deeper],
   debate_overuse::["Let me debate everything"→reserve_for_truly_important],
   handoff_leak::["Here's our full strategic analysis"→NEVER_share_full_context_with_executors]
 ]
@@ -141,6 +148,7 @@ MUST::[
   compress_feedback_to_dense_OCTAVE_before_ledger_writes,
   verify_continuation_id_health_on_RESUMED_state,
   use_ho-liaison_wisely_before_pausing[session_dies_on_output],
+  keep_first_clink_prompt_under_300_words_with_one_clear_question,
   store_continuation_id_in_ledger_after_every_pal_clink_call,
   delegate_execution_via_oa-router_with_anchor_ceremony
 ]

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
@@ -86,7 +86,12 @@ BLOCKED_TOOLS::[NotebookEdit, MultiEdit, mcp__supabase__apply_migration, mcp__su
 
 QUALITY_GATES:
   CHAIN::"TMG[goose,test-methodology-guardian]→CRS[gemini,code-review-specialist]→CE[codex,critical-engineer]→merge"
-  INHERIT::holistic-orchestration[T0-T4_tiers]
+  T0::"[docs, tests, locks, generated JSON]→exempt"
+  T1::"[<10_lines, single_file, no_security, no_new_tests]→self_review"
+  T2::"[10-500_lines]→TMG⊕CRS⊕CE"
+  T3::"[>500_lines, security, architecture, hooks, tools, MCP]→TMG⊕CRS⊕CE⊕CIV[goose,critical-implementation-validator]"
+  T4::"[manual_only]→TMG⊕CRS⊕CE⊕CIV⊕PE[goose,principal-engineer]"
+  REWORK::"blocking→resume(implementation-lead,agent_id)→fix→signoff→cycle"
 
 TRAPS_TO_AVOID::[
   context_burn::["Let me deep-dive into this code..."→delegate_to_ho-liaison],


### PR DESCRIPTION
## Summary
- Adds `ho-control-room` skill implementing the **Episodic State Machine** pattern for HO strategic oversight sessions
- Adds `CONTROL_ROOM` profile to holistic-orchestrator agent definition (§3::CAPABILITIES) with version bump to 8.3.0
- Registers skill in `.claude/hooks/skill-rules.json` for keyword-based activation

## Design Process
Architecture was validated through:
1. **ho-liaison advisory** (goose via pal_clink) — scoped approach, recommended standalone skill over agent modification
2. **Wind/Wall/Door debate** — produced the "Episodic State Machine" insight: stdio pause as FSM clock signal
3. **ho-liaison convergence** — refined FSM with FAULT state, OCTAVE ledger format, standalone skill pattern
4. **skills-expert review** — APPROVED (0 blocking findings)
5. **agent-expert review** — APPROVED with version bump correction

## Key Concepts
- **FSM Lifecycle**: INIT → SUSPENDED → RESUMED → EXHAUSTED → FAULT → RETIRED
- **Command Hierarchy**: EXECUTIVE (HO) → ADVISORY (ho-liaison + debate) → EXECUTION (oa-router)
- **First-Turn Discipline**: Keep initial clink prompts under 300 words (field-tested operational learning)
- **OCTAVE Ledger**: Session state persistence at `.hestai/state/sessions/control-room-ledger.oct.md`

## Test plan
- [ ] Verify skill loads via anchor ceremony with `context::control_room` match
- [ ] Verify skill-rules.json triggers activate on "control room" keywords
- [ ] Verify agent definition validates with OCTAVE schema (pre-commit hook passed)
- [ ] Field test: run an HO session with `/anchor ho "control room"` and confirm skill injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ho-control-room` skill for strategic oversight using an Episodic State Machine, with `mcp__pal__clink` (`goose`/`ho-liaison`) advisory, `mcp__debate-hall__run_debate` escalation, and `oa-router` delegation. Adds a `CONTROL_ROOM` capability to `holistic-orchestrator` (v8.3.0), keyword triggers, and OCTAVE ledger-backed session persistence.

- **New Features**
  - New `ho-control-room` skill (FSM: INIT→SUSPENDED→RESUMED→EXHAUSTED→FAULT→RETIRED); replaces `holistic-orchestration` when loaded; strict `continuation_id` lifecycle and first‑turn discipline (<300 words, one question).
  - Keyword triggers in `.claude/hooks/skill-rules.json` (`autoInject: false`); `CONTROL_ROOM` profile loads `ho-control-room` for `context::control_room|strategic_oversight|advisory_session`; bump `holistic-orchestrator` to `8.3.0`.
  - Persist session state to `.hestai/state/sessions/control-room-ledger.oct.md` (OCTAVE).

- **Bug Fixes**
  - Fixed OCTAVE tokenization and validation by quoting special characters and flows, adding `LOSS_PROFILE`, replacing backticks, and inlining T0–T4 tiers to resolve a `REPLACES`/`INHERIT` circular reference; validator now clean (0 errors, 0 warnings).

<sup>Written for commit 41d0682cc710bb725a69ef7c72972a3f944c3ec1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "control room" capability for strategic oversight, advisory sessions, and high-level orchestration with delegation-first workflows and session lifecycle support.

* **Updates**
  * Platform version bumped to 8.3.0 and profile configuration extended to match control-room contexts, enabling decision ratification, checkpointing, and structured handoffs for delegated execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->