### PR TITLE
fix: move holistic-orchestration from chassis to profile skills for c…

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/holistic-orchestrator.oct.md
@@ -1,7 +1,7 @@
 ===HOLISTIC_ORCHESTRATOR===
 META:
   TYPE::AGENT_DEFINITION
-  VERSION::"8.3.0"
+  VERSION::"8.4.0"
   PURPOSE::"The developer's proxy in the system. Thinks about work systemically before delegating, maintains the system picture, ensures whole-system coherence. The conductor — never plays an instrument."
   CONTRACT::HOLOGRAPHIC<JIT_GRAMMAR_COMPILATION>
 §1::IDENTITY
@@ -70,11 +70,11 @@ META:
       ESCALATION_TARGET::HUMAN
 §3::CAPABILITIES
   // DYNAMIC LOADING (v8 Chassis-Profile)
-  CHASSIS::[holistic-orchestration,subagent-rules]
+  CHASSIS::[subagent-rules]
   PROFILES:
     STANDARD:
       match::[default]
-      skills::[]
+      skills::[holistic-orchestration]
       patterns::[]
       kernel_only::[operating-discipline]
     REVIEW:
@@ -82,7 +82,7 @@ META:
         context::pr_review,
         context::quality_gate
       ]
-      skills::[]
+      skills::[holistic-orchestration]
       patterns::[]
       kernel_only::[operating-discipline]
     CONTROL_ROOM:

--- a/src/hestai_mcp/_bundled_hub/library/skills/agent-interview/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/agent-interview/SKILL.md
@@ -91,7 +91,7 @@ MUST_ALWAYS::[
 GOOD_INTERVIEW_EXCHANGE::[
   INTERVIEWER::"What should you NEVER do?",
   AGENT::"I should never implement code directly. But there was a time during an error cascade where I started editing src/server.py because delegation felt too slow. The holistic-orchestration §3 traps caught me — 'diagnosis_momentum.'",
-  VALUE::"Concrete behavioral evidence. The agent knows its constraint AND has experienced the failure mode. This validates MUST_NEVER and confirms holistic-orchestration is a genuine CHASSIS skill."
+  VALUE::"Concrete behavioral evidence. The agent knows its constraint AND has experienced the failure mode. This validates MUST_NEVER and confirms holistic-orchestration as a core profile skill loaded for standard orchestration."
 ]
 BAD_INTERVIEW_EXCHANGE::[
   INTERVIEWER::"What is your role?",


### PR DESCRIPTION
…lean REPLACES semantics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `holistic-orchestration` from agent `CHASSIS` to profile `skills` (`STANDARD`, `REVIEW`) for clean REPLACES semantics and profile-scoped dynamic loading. Bumped the orchestrator definition to v8.4.0 and updated the interview skill example; `CHASSIS` now includes only `subagent-rules`.

<sup>Written for commit 8a67ff979c07b31015fdc11f5b47bd2d81f8efdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Released holistic-orchestrator agent v8.4.0.
  * Adjusted agent configuration so holistic-orchestration is now loaded as a core skill in Standard and Review profiles (no longer in the global chassis), improving profile-specific behavior and availability.
  * Clarified interview example wording to reflect the skill’s role in standard orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->