### PR TITLE
feat: upgrade octave-mastery skill to v3.0.0

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-mastery/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-mastery/SKILL.md
@@ -125,9 +125,9 @@ DECISION::["adopt microservices"∧REQ]
 ===END===
       ```
 §5::BLOCK_NOTATION_RULE
-  // Hierarchical content MUST use block notation — this is a NEVER rule with an error code
+  // Hierarchical content MUST use block notation
   RULE::"Nested structures (maps containing maps) MUST use BLOCK notation: single colon + indented children"
-  NEVER::"Inline map nesting: KEY::[inner::val, inner2::val2] is invalid when inner values are themselves maps"
+  NEVER::"Inner value is itself an inline map: KEY::[outer::[inner::val]] — error E_NESTED_INLINE_MAP in strict mode, warning W_NESTED_INLINE_MAP in lenient mode"
   PRIMARY_CASE::"Agent §2::BEHAVIOR definitions — CONDUCT, PROTOCOL, OUTPUT blocks require block notation"
   CORRECT:
     ```

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-mastery/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-mastery/SKILL.md
@@ -1,107 +1,147 @@
 ---
 name: octave-mastery
-description: Advanced semantic vocabulary and architectural patterns for the OCTAVE format. REQUIRES octave-literacy to be loaded first
+description: "Advanced semantic vocabulary, holographic contracts, and structural patterns for OCTAVE. REQUIRES octave-literacy. Extends literacy with mythology, archetype annotation, v6 contracts, and anti-pattern rules."
 allowed-tools: ["Read", "Write", "Edit"]
-triggers: ["octave architecture", "agent design", "semantic pantheon", "advanced octave", "OCTAVE mastery", "holographic patterns", "archetypes", "high-density specifications", "system architecture", "OCTAVE patterns"]
-version: "2.4.0"
+triggers: ["octave architecture", "agent design", "semantic pantheon", "advanced octave", "OCTAVE mastery", "holographic patterns", "archetypes", "high-density specifications", "system architecture", "holographic contracts", "archetype annotation"]
+version: "3.0.0"
 ---
 
 ===OCTAVE_MASTERY===
 META:
   TYPE::SKILL
-  VERSION::"2.4.0"
+  VERSION::"3.0.0"
   STATUS::ACTIVE
-  PURPOSE::"Expert-level OCTAVE application: Archetypes, Advanced Syntax, Strategy"
-  OCTAVE::"Olympian Common Text And Vocabulary Engine — Semantic DSL for LLMs"
+  PURPOSE::"Expert-level OCTAVE: mythology vocabulary, holographic contracts, archetype annotation, anti-patterns"
   REQUIRES::octave-literacy
-  TIER::LOSSLESS
   SPEC_REFERENCE::octave-core-spec.oct.md
-  V6_FEATURES::"Holographic contracts, JIT grammar compilation, constraint validation"
-
+---
 §1::SEMANTIC_PANTHEON
-  // Core vocabulary for semantic compression — extensible, not closed
-  // See octave-mythology §10::EXTENSION_POINTS for expansion guidance
+  // Compression vocabulary — zero-shot, use directly. Literal term wins when equally clear.
+  // Use as KEY prefixes (ARTEMIS::latency_p99) or PATTERN DESCRIPTORS (SISYPHEAN_DEBT).
   DOMAINS:
-    ZEUS::"Executive function, authority, strategic direction, final arbitration"
-    ATHENA::"Strategic wisdom, planning, elegant solutions, deliberate action"
-    APOLLO::"Analytics, data, insight, clarity, prediction, revealing truth"
-    HERMES::"Communication, translation, APIs, networking, messaging, speed"
-    HEPHAESTUS::"Infrastructure, tooling, engineering, automation, system architecture"
-    ARES::"Security, defense, stress testing, conflict simulation, adversarial analysis"
-    ARTEMIS::"Monitoring, observation, logging, alerting, precision targeting of issues"
-    POSEIDON::"Data lakes, storage, databases, unstructured data pools"
-    DEMETER::"Resource allocation, budgeting, system growth, scaling"
-    DIONYSUS::"User experience, engagement, creativity, chaotic innovation"
-
-§2::NARRATIVE_DYNAMICS
-  PATTERNS:
-    ODYSSEAN::"Long, transformative journey with a clear goal"
-    SISYPHEAN::"Repetitive, endless maintenance (e.g., tech debt)"
-    PROMETHEAN::"Breakthrough innovation challenging the status quo"
-    ICARIAN::"Overreach due to early success leading to failure"
-    PANDORAN::"Action unleashing complex, unforeseen problems"
-    TROJAN::"Hidden payload changing system from within"
-    GORDIAN::"Unconventional solution to impossible problem"
+    ZEUS::"Executive authority, final arbitration, strategic direction"
+    ATHENA::"Strategic wisdom, planning, elegant solutions"
+    APOLLO::"Analytics, insight, clarity, prediction"
+    HERMES::"Communication, APIs, translation, messaging"
+    HEPHAESTUS::"Infrastructure, tooling, engineering, automation"
+    ARES::"Security, defense, stress testing, adversarial analysis"
+    ARTEMIS::"Monitoring, alerting, precision targeting, observation"
+    POSEIDON::"Storage, databases, data lakes, unstructured pools"
+    DEMETER::"Resource allocation, budgeting, scaling, growth"
+    DIONYSUS::"UX, engagement, creativity, chaotic innovation"
+§2::NARRATIVE_FORCES
+  // Single-token state and trajectory descriptors
+  TRAJECTORIES:
+    ODYSSEAN::"Long transformative journey with clear goal"
+    SISYPHEAN::"Repetitive endless maintenance"
+    PROMETHEAN::"Breakthrough challenging status quo"
+    ICARIAN::"Overreach from early success → failure"
+    PANDORAN::"Action unleashing unforeseen cascades"
+    TROJAN::"Hidden payload transforming system from within"
+    GORDIAN::"Unconventional cut through impossible problem"
     ACHILLEAN::"Single critical point of failure"
-    PHOENICIAN::"Necessary destruction and rebirth (refactoring)"
-
-§3::SYSTEM_FORCES
-  DYNAMICS:
+    PHOENICIAN::"Necessary destruction and rebirth"
+  FORCES:
+    KAIROS::"Critical fleeting opportunity window"
+    CHRONOS::"Linear time pressure"
     HUBRIS::"Dangerous overconfidence"
     NEMESIS::"Inevitable corrective consequence"
-    KAIROS::"Critical, fleeting window of opportunity"
-    CHRONOS::"Constant linear time pressure"
     CHAOS::"Entropy and disorder"
-    COSMOS::"Emergence of order"
-
-§4::ADVANCED_SYNTAX
-  // Extends octave-literacy with holographic and type patterns
-  HOLOGRAPHIC::KEY::["value"∧CONSTRAINT→§TARGET]
-  INLINE_MAP::[key::value, key2::value2][values_must_be_atoms,no_nesting]
-  TYPE_DISAMBIGUATION::[
-    STRING::"42",
-    NUMBER::42,
-    BOOL::true
+    COSMOS::"Emergence of order from complexity"
+§3::ARCHETYPE_ANNOTATION
+  // Archetypes in agent definitions use NAME<qualifier> annotation form
+  // <qualifier> is a semantic facet, not a list. It narrows what the archetype IS in this context.
+  SYNTAX::ARCHETYPE_NAME<behavioral_facet>
+  CORRECT::[
+    HEPHAESTUS<faithful_transcription>,
+    ATLAS<reliable_execution>,
+    ATHENA<strategic_wisdom>,
+    HERMES<format_translation>
   ]
-
-  §4b::V6_HOLOGRAPHIC_CONTRACTS
-    // v6 innovation: Documents carry their own validation law
-    CONTRACT::HOLOGRAPHIC[
-      PRINCIPLE::"Validation rules embedded in document META block",
-      MECHANISM::JIT_GRAMMAR_COMPILATION[META→GBNF],
-      ANCHORING::HERMETIC[frozen@sha256|latest@local],
-      BENEFIT::"Self-validating documents, no external schema needed"
-    ]
-    GRAMMAR::[
-      GENERATOR::OCTAVE_GBNF_COMPILER[planned],
-      INTEGRATION::[llama.cpp,Outlines,vLLM],
-      OUTPUT::"Constrained generation - impossible to produce invalid syntax"
-    ]
-    EXAMPLE_META::[
-      CONTRACT::TYPE_CONSTRAINTS[field1::STRING,field2::NUMBER],
-      GRAMMAR::GBNF[rules_for_structured_output]
-    ]
-
-§4c::CONSTRAINTS
-  // Available constraint types for holographic patterns
-  CORE::[REQ,OPT,CONST,ENUM,TYPE,REGEX,DIR,APPEND_ONLY]
-  EXTENDED::[RANGE,MAX_LENGTH,MIN_LENGTH,DATE,ISO8601]
-  EXAMPLES::[
-    "REQ"[required_field],
-    "ENUM[A,B,C]"[enumerated_values],
-    "RANGE[1,10]"[numeric_bounds],
-    "MAX_LENGTH[50]"[string_or_list_max],
-    "DATE"[strict_YYYY_MM_DD],
-    "ISO8601"[full_datetime]
-  ]
-  V6_USAGE::constraints_in_CONTRACT_block[self_contained_validation]
-
-§5::ANTI_PATTERNS
-  SMELLS::[
-    "Isolated Lists (no relationships)",
-    "Flat Hierarchies (lack of grouping)",
-    "Buried Networks (relationships hidden in prose)",
-    "Operator Soup (A+B->C~D all in one line)"
-  ]
-
+  // The <qualifier> activates a specific behavioral dimension of the archetype.
+  // Do NOT use NAME[qualifier] for archetypes — that is constructor syntax, not annotation.
+  // Do NOT stack multiple qualifiers: HEPHAESTUS<a,b> is invalid. Use one facet per archetype.
+  ANTI_PATTERN::"HEPHAESTUS[faithful_transcription] — wrong bracket form for archetype annotation"
+  MULTI_ARCH::"[HEPHAESTUS<faithful_transcription>, ATLAS<reliable_execution>] — list of annotated archetypes"
+§4::HOLOGRAPHIC_CONTRACTS
+  // v6: Documents carry their own validation law in META. Two distinct uses:
+  // (A) CONTRACT in META = document-level validation law (what this document must contain)
+  // (B) HOLOGRAPHIC pattern in BODY = field-level constraint (what this field must satisfy)
+  §4a::CONTRACT_IN_META
+    // Place in META block. Defines validation rules for the whole document.
+    FORM::"CONTRACT::HOLOGRAPHIC<validation_law_in_document>"
+    // CONTRACT value is an annotation — use <> not []
+    // The holographic compiler reads META.CONTRACT to validate all fields below.
+    ANCHORING:
+      FROZEN::"CONTRACT::HOLOGRAPHIC<frozen@sha256_abc123> — locks schema to specific hash, hermetic"
+      LATEST::"CONTRACT::HOLOGRAPHIC<latest@local> — resolves to current local schema, mutable"
+    // Use frozen@ for production documents requiring reproducibility.
+    // Use latest@local for active development documents.
+    GRAMMAR_FIELD::"GRAMMAR::GBNF_COMPILER<generate_constrained_output> — emits GBNF for constrained generation"
+  §4b::HOLOGRAPHIC_BODY_PATTERN
+    // Field-level constraint in BODY. Syntax: KEY::["value"∧CONSTRAINT→§TARGET]
+    // The brackets contain: value ∧ constraint → routing target
+    SYNTAX_BREAKDOWN:
+      VALUE::"the literal value or expression"
+      CONSTRAINT::"REQ, OPT, ENUM[a,b], REGEX[pattern], RANGE[min,max], MAX_LENGTH[n], ISO8601, DATE"
+      TARGET::"§SECTION — where validated values route (optional)"
+    EXAMPLE:
+      ```
+STATUS::["ACTIVE"∧ENUM[ACTIVE,DRAFT,DEPRECATED]→§LIFECYCLE]
+PRIORITY::["HIGH"∧ENUM[HIGH,MEDIUM,LOW]]
+LATENCY::["<200ms"∧REGEX[<\d+ms]]
+      ```
+    CONSTRAINT_TYPES:
+      CORE::[
+        REQ,
+        OPT,
+        CONST,
+        ENUM,
+        TYPE,
+        REGEX,
+        DIR,
+        APPEND_ONLY
+      ]
+      EXTENDED::[
+        RANGE,
+        MAX_LENGTH,
+        MIN_LENGTH,
+        DATE,
+        ISO8601
+      ]
+  §4c::CONTRACT_BLOCK_EXAMPLE
+    // Full META block using CONTRACT for a typed document
+    EXAMPLE:
+      ```
+===MY_DOCUMENT===
+META:
+  TYPE::DECISION
+  VERSION::"1.0.0"
+  CONTRACT::HOLOGRAPHIC<latest@local>
+---
+STATUS::["ACTIVE"∧ENUM[ACTIVE,DRAFT,DEPRECATED]]
+OWNER::["team-name"∧REQ]
+DECISION::["adopt microservices"∧REQ]
+===END===
+      ```
+§5::BLOCK_NOTATION_RULE
+  // Hierarchical content MUST use block notation — this is a NEVER rule with an error code
+  RULE::"Nested structures (maps containing maps) MUST use BLOCK notation: single colon + indented children"
+  NEVER::"Inline map nesting: KEY::[inner::val, inner2::val2] is invalid when inner values are themselves maps"
+  PRIMARY_CASE::"Agent §2::BEHAVIOR definitions — CONDUCT, PROTOCOL, OUTPUT blocks require block notation"
+  CORRECT:
+    ```
+CONDUCT:
+  TONE::"Precise"
+  PROTOCOL:
+    MUST_ALWAYS::[rule_a, rule_b]
+    ```
+  WRONG::"CONDUCT::[TONE::\"Precise\", PROTOCOL::[MUST_ALWAYS::[rule_a]]]"
+§6::ANTI_PATTERNS
+  // Each has a concrete example of what NOT to do
+  ISOLATED_LIST::"[auth, payments, users] with no relationships — use DECISION::microservice_extraction[auth⊕payments→independent_services] instead"
+  FLAT_HIERARCHY::"All keys at top level with no grouping — group related keys under a parent BLOCK"
+  BURIED_NETWORK::"RELATED_TO::other_service hidden in prose comment — use explicit operator: auth→payments[dependency]"
+  OPERATOR_SOUP::"RESULT::A+B->C~D all in one expression — break into separate keyed fields"
+  PROSE_BLEED::"Using natural language sentences as values — every token must carry semantic payload"
 ===END===


### PR DESCRIPTION
## Summary
- Upgrades `octave-mastery` SKILL.md from v2.4.0 to v3.0.0 based on secretary ideal benchmark output
- New `§3::ARCHETYPE_ANNOTATION` — explicit guidance on `NAME<qualifier>` for agent archetypes with anti-patterns
- Restructured `§4::HOLOGRAPHIC_CONTRACTS` into three clear subsections: CONTRACT_IN_META, HOLOGRAPHIC_BODY_PATTERN, CONTRACT_BLOCK_EXAMPLE
- New `§5::BLOCK_NOTATION_RULE` — NEVER rule for nested inline maps with correct/wrong examples
- Merged narrative dynamics + system forces into `§2::NARRATIVE_FORCES`
- Expanded `§6::ANTI_PATTERNS` with 5 concrete examples including fixes
- Leaner META (drops redundant OCTAVE definition already in literacy)

## Test plan
- [x] All quality gates pass (ruff, mypy, pytest — 1017 tests, 92% coverage)
- [x] Pre-commit hooks pass
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `octave-mastery` to v3.0.0 with archetype annotations, v6 holographic contracts, and a strict block-notation rule. Unifies narrative/system forces and expands anti-patterns with concrete fixes.

- **New Features**
  - Adds §3 archetype annotation using `NAME<qualifier>` with single-facet guidance and anti-patterns.
  - Restructures §4 holographic contracts: document-level `CONTRACT::HOLOGRAPHIC<…>` in META, field-level body pattern, anchors (`frozen@sha256`, `latest@local`), plus a full example.
  - Introduces §5 NEVER rule for nested inline maps; hierarchical content must use block notation, with explicit `E_NESTED_INLINE_MAP` (strict) and `W_NESTED_INLINE_MAP` (lenient) codes.
  - Merges narrative dynamics and system forces into `§2::NARRATIVE_FORCES`; trims META and updates triggers.

- **Migration**
  - Use `NAME<qualifier>` for archetypes; do not use brackets `[]` or multiple qualifiers.
  - Move document-level constraints to META via `CONTRACT::HOLOGRAPHIC<latest@local>` or `<frozen@sha256_…>`; keep field constraints in the body.
  - Replace any nested inline maps with block notation.
  - Update references to `§2::NARRATIVE_FORCES` and bump dependent references to `version: "3.0.0"`.

<sup>Written for commit c488e7a49c327cedfabac25cfa887261f2a7b78a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

