### PR TITLE
feat: upgrade octave-compression skill to v3.0.0

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
@@ -68,7 +68,8 @@ META:
   // I4::TRANSFORM_AUDITABILITY — every transformation must log what was preserved vs dropped.
   // These META fields are MANDATORY for any compressed output.
   REQUIRED_META_FIELDS::[COMPRESSION_TIER,LOSS_PROFILE]
-  LOSS_PROFILE_FORMAT::[preserve:X,drop:Y] — explicit, never hidden
+  LOSS_PROFILE_FORMAT::[preserve:X,drop:Y]
+  // LOSS_PROFILE must be explicit — never hidden
   EXAMPLES:
     CONSERVATIVE::[preserve:causal_chains,drop:verbose_phrasing]
     AGGRESSIVE::[preserve:core_thesis∧conclusions,drop:explanatory_depth∨edge_cases]

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
@@ -1,107 +1,139 @@
 ---
 name: octave-compression
-description: Specialized workflow for transforming verbose natural language into semantic OCTAVE structures. REQUIRES octave-literacy to be loaded first
+description: "Workflow for transforming prose into semantic OCTAVE structures. Covers tier selection, transformation phases, loss accounting, and decision rules. REQUIRES octave-literacy."
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["compress to octave", "semantic compression", "documentation refactoring", "octave compression", "compress documentation", "knowledge artifact", "semantic density", "OCTAVE format conversion"]
-version: "2.6.0"
+version: "3.0.0"
 ---
 
 ===OCTAVE_COMPRESSION===
 META:
   TYPE::SKILL
-  VERSION::"2.6.0"
+  VERSION::"3.0.0"
   STATUS::ACTIVE
-  PURPOSE::"Workflow for transforming prose into semantic density"
-  OCTAVE::"Olympian Common Text And Vocabulary Engine — Semantic DSL for LLMs"
+  PURPOSE::"Decision rules and workflow for transforming prose into semantic OCTAVE at the correct fidelity tier"
   REQUIRES::octave-literacy
-  TIER::LOSSLESS
   SPEC_REFERENCE::octave-data-spec.oct.md
-  V6_FEATURES::"Loss accounting system, tier metadata tracking, fidelity guarantees"
-
-§1::COMPRESSION_MANDATE
-  TARGET::"60-80% token reduction with 100% decision-logic fidelity"
-  PRINCIPLE::"Semantics > Syntax Rigidity"
-  TRUTH::"Dense ≠ Obscure. Preserve the causal chain."
-
-  §1b::COMPRESSION_TIER_SELECTION
-    // Full tier definitions in octave-data-spec.oct.md
-    LOSSLESS::[target:100%_fidelity,preserve:everything,drop:none]
-      USE::[critical_reasoning,legal_documents,safety_analysis,audit_trails]
-    CONSERVATIVE::[target:85-90%_compression,preserve:explanatory_depth,drop:redundancy]
-      USE::[research_summaries,design_decisions,technical_analysis]
-      LOSS::~10-15%[repetition,some_edge_cases,verbose_phrasing]
-    AGGRESSIVE::[target:70%_compression,preserve:core_thesis∧conclusions,drop:nuance∨narrative]
-      USE::[context_window_scarcity,quick_reference,decision_support]
-      LOSS::~30%[explanatory_depth,execution_tradeoff_narratives,edge_case_exploration]
-    ULTRA::[target:50%_compression,preserve:facts∧structure,drop:all_narrative]
-      USE::[extreme_scarcity,embedding_generation,dense_reference]
-      LOSS::~50%[almost_all_explanatory_content,some_nuance,tradeoff_reasoning]
-
-    // Note: For 60% compression with mythological atoms, see octave-ultra-mythic skill
-    ULTRA_MYTHIC::[target:60%_compression,preserve:soul∧constraints,method:mythological_atoms]
-      REFERENCE::skills/octave-ultra-mythic[specialized_identity_compression]
-
-    TIER_METADATA::include_in_META_block[COMPRESSION_TIER,LOSS_PROFILE,NARRATIVE_DEPTH]
-
-    V6_LOSS_ACCOUNTING::[
-      PRINCIPLE::"OCTAVE-MCP is a loss accounting system for LLM communication",
-      TRACKING::"Every transformation must log what was preserved vs dropped",
-      METADATA::"Documents carry their compression tier and loss profile",
-      AUDIT::I4_TRANSFORM_AUDITABILITY[stable_ids,loss_receipts],
-      FIDELITY::I1_SYNTACTIC_FIDELITY[syntax_changes_ok,semantics_preserved]
+---
+§1::TIER_SELECTION
+  // Choose tier BEFORE reading source. Tier drives every subsequent decision.
+  TIERS:
+    LOSSLESS:
+      TARGET::"100%_fidelity"
+      PRESERVE::everything
+      DROP::nothing
+      USE::[
+        critical_reasoning,
+        legal_documents,
+        safety_analysis,
+        audit_trails
+      ]
+    CONSERVATIVE:
+      TARGET::"85-90%_fidelity"
+      PRESERVE::explanatory_depth
+      DROP::redundancy
+      LOSS::"10-15%[repetition,verbose_phrasing,some_edge_cases]"
+      USE::[
+        research_summaries,
+        design_decisions,
+        technical_analysis
+      ]
+    AGGRESSIVE:
+      TARGET::"70%_fidelity"
+      PRESERVE::core_thesis∧conclusions
+      DROP::nuance∨narrative
+      LOSS::"30%[explanatory_depth,tradeoff_narratives,edge_case_exploration]"
+      USE::[
+        context_window_scarcity,
+        quick_reference,
+        decision_support
+      ]
+    ULTRA:
+      TARGET::"50%_fidelity"
+      PRESERVE::facts∧structure
+      DROP::all_narrative
+      LOSS::"50%[almost_all_explanatory_content,tradeoff_reasoning]"
+      USE::[
+        extreme_scarcity,
+        embedding_generation,
+        dense_reference
+      ]
+  DECISION_RULES::[
+    "IF[reconstruction_accuracy_critical]→CONSERVATIVE∨LOSSLESS",
+    "IF[context_window_scarce∧loss_acceptable]→AGGRESSIVE∨ULTRA",
+    "IF[decision_relevant_facts_must_survive]→CONSERVATIVE⊕mythology_domain_labels",
+    DEFAULT→CONSERVATIVE
+  ]
+§2::LOSS_ACCOUNTING
+  // I4::TRANSFORM_AUDITABILITY — every transformation must log what was preserved vs dropped.
+  // These META fields are MANDATORY for any compressed output.
+  REQUIRED_META_FIELDS::[COMPRESSION_TIER,LOSS_PROFILE]
+  LOSS_PROFILE_FORMAT::"[preserve:X,drop:Y] — explicit, never hidden"
+  EXAMPLES:
+    CONSERVATIVE::"[preserve:causal_chains,drop:verbose_phrasing]"
+    AGGRESSIVE::"[preserve:core_thesis∧conclusions,drop:explanatory_depth∨edge_cases]"
+    ULTRA::"[preserve:facts∧structure,drop:all_narrative∨tradeoff_reasoning]"
+  META_BLOCK_TEMPLATE:
+    ```
+META:
+  TYPE::DECISION
+  VERSION::"1.0.0"
+  COMPRESSION_TIER::CONSERVATIVE
+  LOSS_PROFILE::"[preserve:causal_chains,drop:verbose_phrasing]"
+    ```
+  I4_RULE::"If bits were dropped, the output must carry a receipt. No silent loss."
+§3::TRANSFORMATION_WORKFLOW
+  PHASE_1_READ:
+    MAP::"Identify all causal chains (A causes B, X requires Y)"
+    IDENTIFY::[
+      Redundancy,
+      Verbosity,
+      Conditional_Qualifiers
     ]
-
-§2::TRANSFORMATION_WORKFLOW
-  PHASE_1_READ::[
-    ANALYZE::"Understand before compressing",
-    IDENTIFY::[Redundancy, Verbosity, Causal_Chains],
-    MAP::"Logic flow (A leads to B)"
-  ]
-
-  PHASE_2_EXTRACT::[
-    CORE_PATTERNS::"Essential decision logic",
-    REASONING::"BECAUSE statements (preserve the 'why')",
-    EVIDENCE::"Metrics and concrete examples",
-    TRANSFER::"HOW-to mechanics"
-  ]
-
-  PHASE_3_COMPRESS::[
-    APPLICATION::"Apply operators defined in octave-literacy",
-    HIERARCHY::"Group related concepts under parent keys",
-    ARRAYS::"Convert repetitive lists to [item1, item2]",
-    MYTHOLOGY::"For fidelity, use domain labels (§3b). For 60% compression, load octave-ultra-mythic for mythological atoms"
-  ]
-
-  PHASE_4_VALIDATE::[
-    FIDELITY::"Is the logic intact?",
-    GROUNDING::"Is there at least 1 concrete example?",
-    NAVIGABILITY::"Can a human scan it?"
-  ]
-
-§3::COMPRESSION_RULES
-  RULE_1::"Preserve CAUSALITY (X→Y because Z)"
-  RULE_2::"Drop stopwords (the, is, a, of)"
-  RULE_3::"One example per 200 tokens of abstraction"
-  RULE_4::"Explicit Tradeoffs (GAIN⇌LOSS or GAIN vs LOSS)"
-  RULE_5::"Preserve CONDITIONAL QUALIFIERS (when X, if Y, unless Z) — they carry material risk info, not hedging"
-  RULE_6::"Use mythology as DOMAIN LABELS (ARTEMIS::, CHRONOS::, DEMETER:: as key prefixes) when fidelity matters — domain labels anchor facts and prevent reconstruction drift"
-  RULE_7::"Use mythology as PATTERN DESCRIPTORS (SISYPHEAN, ODYSSEAN) when semantic density matters — encodes trajectories and states in single terms"
-
-  §3b::CONSERVATIVE_MYTH_TECHNIQUE
-    // Combine CONSERVATIVE compression with mythology domain labels for maximum fidelity
-    WHEN::"Decision-relevant content where reconstruction accuracy matters more than minimum tokens"
-    METHOD::"Use mythology terms as KEY prefixes (CHRONOS::audit_6wk) not embedded values (pressure::audit_6wk∧CHRONOS)"
-    WHY::"Domain labels are reconstruction anchors — agents translate each labeled field separately instead of merging into compound sentences"
-    RESULT::"11/11 decision-relevant facts preserved at 15% fewer tokens than original prose"
-    EVIDENCE::octave-mcp[docs/research/compression-fidelity-round-trip-study.md]
-    LOSSLESS_FIDELITY_AT_CONSERVATIVE_COST::true
-
-§4::ANTI_PATTERNS
-  AVOID::[
-    "Markdown inside OCTAVE blocks",
-    "JSON/YAML syntax (no curly braces, no trailing commas)",
-    "Deep nesting (>3 levels)",
-    "Loss of numbers or IDs"
-  ]
-
+    NOTE::"Conditional qualifiers (when X, if Y, unless Z) carry material risk — never drop"
+  PHASE_2_EXTRACT:
+    PRESERVE::[
+      causal_chains,
+      BECAUSE_statements,
+      metrics,
+      conditional_qualifiers
+    ]
+    COMPRESS::[
+      stopwords,
+      repetition,
+      verbose_phrasing,
+      narrative_connectives
+    ]
+    ANCHOR::"One concrete example per major abstraction — anchors reconstruction fidelity"
+  PHASE_3_COMPRESS:
+    OPERATORS::"Apply ⊕ ⇌ → ∧ ∨ from octave-literacy §2"
+    HIERARCHY::"Group related concepts under parent BLOCK keys"
+    MYTHOLOGY::"Use domain label prefixes (ARTEMIS::, CHRONOS::) to anchor facts — see §5"
+    ARRAYS::"Convert parallel items to [item1,item2,item3]"
+  PHASE_4_VALIDATE:
+    FIDELITY::"Are all causal chains intact?"
+    LOSS_RECEIPT::"Does META carry COMPRESSION_TIER and LOSS_PROFILE?"
+    GROUNDING::"Is there at least one concrete example per major abstraction?"
+    WARNINGS::"Check octave_write warnings[] — W_BARE_LINE_DROPPED and W_NUMERIC_KEY_DROPPED are silent data loss"
+§4::COMPRESSION_RULES
+  R1::"Preserve CAUSALITY — X→Y because Z. Never flatten to X→Y alone."
+  R2::"Preserve CONDITIONAL QUALIFIERS — when X, if Y, unless Z carry material risk info"
+  R3::"Preserve EXPLICIT TRADEOFFS — GAIN⇌LOSS or GAIN vs LOSS"
+  R4::"One concrete example per major abstraction — minimum reconstruction anchor"
+  R5::"Use mythology as KEY PREFIXES (CHRONOS::audit_6wk) not embedded values — domain labels are reconstruction anchors"
+  R6::"Use mythology as PATTERN DESCRIPTORS (SISYPHEAN,ODYSSEAN) for single-token trajectory encoding"
+  R7::"Never drop numbers, IDs, thresholds, or named entities — these are irreplaceable"
+§5::CONSERVATIVE_PLUS_MYTHOLOGY
+  // CONSERVATIVE compression + mythology domain labels = maximum fidelity at minimum tokens
+  WHEN::"Decision-relevant content where reconstruction accuracy matters more than minimum tokens"
+  METHOD::"Use mythology terms as KEY prefixes (CHRONOS::audit_6wk) not embedded values"
+  WHY::"Domain labels force agents to translate each labeled field separately — prevents fact merging"
+  RESULT::"11/11 decision-relevant facts preserved at 15% fewer tokens than original prose"
+  EVIDENCE::"octave-mcp<docs/research/compression-fidelity-round-trip-study.md>"
+§6::ANTI_PATTERNS
+  AP1::"Markdown inside OCTAVE blocks — no bold, no headers, no bullet hyphens"
+  AP2::"JSON/YAML syntax — no curly braces, no trailing commas, no YAML bullet hyphens"
+  AP3::"Deep nesting beyond 3 levels — restructure with parent BLOCK keys"
+  AP4::"Silent loss — always declare COMPRESSION_TIER and LOSS_PROFILE in META"
+  AP5::"Paradigm drift — validate for LLM parse efficiency, not human readability"
 ===END===

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
@@ -80,7 +80,7 @@ META:
   TYPE::DECISION
   VERSION::"1.0.0"
   COMPRESSION_TIER::CONSERVATIVE
-  LOSS_PROFILE::"[preserve:causal_chains,drop:verbose_phrasing]"
+  LOSS_PROFILE::[preserve:causal_chains,drop:verbose_phrasing]
     ```
   I4_RULE::"If bits were dropped, the output must carry a receipt. No silent loss."
 §3::TRANSFORMATION_WORKFLOW

--- a/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/octave-compression/SKILL.md
@@ -62,17 +62,17 @@ META:
     "IF[reconstruction_accuracy_critical]→CONSERVATIVE∨LOSSLESS",
     "IF[context_window_scarce∧loss_acceptable]→AGGRESSIVE∨ULTRA",
     "IF[decision_relevant_facts_must_survive]→CONSERVATIVE⊕mythology_domain_labels",
-    DEFAULT→CONSERVATIVE
+    "DEFAULT→CONSERVATIVE"
   ]
 §2::LOSS_ACCOUNTING
   // I4::TRANSFORM_AUDITABILITY — every transformation must log what was preserved vs dropped.
   // These META fields are MANDATORY for any compressed output.
   REQUIRED_META_FIELDS::[COMPRESSION_TIER,LOSS_PROFILE]
-  LOSS_PROFILE_FORMAT::"[preserve:X,drop:Y] — explicit, never hidden"
+  LOSS_PROFILE_FORMAT::[preserve:X,drop:Y] — explicit, never hidden
   EXAMPLES:
-    CONSERVATIVE::"[preserve:causal_chains,drop:verbose_phrasing]"
-    AGGRESSIVE::"[preserve:core_thesis∧conclusions,drop:explanatory_depth∨edge_cases]"
-    ULTRA::"[preserve:facts∧structure,drop:all_narrative∨tradeoff_reasoning]"
+    CONSERVATIVE::[preserve:causal_chains,drop:verbose_phrasing]
+    AGGRESSIVE::[preserve:core_thesis∧conclusions,drop:explanatory_depth∨edge_cases]
+    ULTRA::[preserve:facts∧structure,drop:all_narrative∨tradeoff_reasoning]
   META_BLOCK_TEMPLATE:
     ```
 META:
@@ -129,7 +129,7 @@ META:
   METHOD::"Use mythology terms as KEY prefixes (CHRONOS::audit_6wk) not embedded values"
   WHY::"Domain labels force agents to translate each labeled field separately — prevents fact merging"
   RESULT::"11/11 decision-relevant facts preserved at 15% fewer tokens than original prose"
-  EVIDENCE::"octave-mcp<docs/research/compression-fidelity-round-trip-study.md>"
+  EVIDENCE::octave-mcp[docs/research/compression-fidelity-round-trip-study.md]
 §6::ANTI_PATTERNS
   AP1::"Markdown inside OCTAVE blocks — no bold, no headers, no bullet hyphens"
   AP2::"JSON/YAML syntax — no curly braces, no trailing commas, no YAML bullet hyphens"


### PR DESCRIPTION
## Summary
- Upgrades `octave-compression` SKILL.md from v2.6.0 to v3.0.0 based on secretary ideal benchmark
- Restructured `§1::TIER_SELECTION` with proper BLOCK notation per tier and `DECISION_RULES` array
- New `§2::LOSS_ACCOUNTING` — dedicated section with required META fields, per-tier examples, META_BLOCK_TEMPLATE, I4 rule
- Restructured `§3::TRANSFORMATION_WORKFLOW` with BLOCK per phase, adds WARNINGS check for octave_write
- Rewritten `§4::COMPRESSION_RULES` as R1-R7 with mythology guidance and never-drop-numbers rule
- Promoted `§5::CONSERVATIVE_PLUS_MYTHOLOGY` to own section with evidence reference
- Expanded `§6::ANTI_PATTERNS` to 5 coded items (AP1-AP5) including paradigm drift
- Dropped redundant META (OCTAVE, TIER, V6_FEATURES, ULTRA_MYTHIC reference)

## Test plan
- [x] All quality gates pass (ruff, mypy, pytest — 1017 tests, 92% coverage)
- [x] Pre-commit hooks pass
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `octave-compression` to v3.0.0 with tier‑first decision rules and mandatory loss receipts in META. Tightens preservation rules and fixes parsing for structured `DECISION_RULES`/`LOSS_PROFILE`/`EVIDENCE`, including an unquoted structured `LOSS_PROFILE` in the META template.

- **New Features**
  - Restructured `§1::TIER_SELECTION` with block notation and `DECISION_RULES`.
  - New `§2::LOSS_ACCOUNTING` with required `COMPRESSION_TIER` and `LOSS_PROFILE`, examples, and a META template.
  - Updated `§3::TRANSFORMATION_WORKFLOW` per phase; adds `octave_write` warnings check.
  - Rewritten `§4::COMPRESSION_RULES` (R1–R7), including mythology guidance and “never drop numbers/IDs”.
  - Promoted `§5` and expanded `§6` anti‑patterns (AP1–AP5); removed redundant META fields.
  - Parser compliance fixes: quote `DEFAULT→CONSERVATIVE`; parse `LOSS_PROFILE`/EXAMPLES as inline maps; separate prose from `LOSS_PROFILE_FORMAT`; use `NAME[path]` for `EVIDENCE`; unquote `LOSS_PROFILE` in the META template.

- **Migration**
  - Include `COMPRESSION_TIER` and `LOSS_PROFILE` in every output META; no silent loss.
  - Use structured `LOSS_PROFILE` as `[preserve:X,drop:Y]` (unquoted) to match the template and examples.
  - Choose a tier before transforming; default to CONSERVATIVE when unsure.
  - Use mythology as key prefixes for high‑fidelity cases; keep numbers/IDs intact.
  - Monitor `octave_write` warnings and fix `W_BARE_LINE_DROPPED` / `W_NUMERIC_KEY_DROPPED`.

<sup>Written for commit bd8bfb76fee539d456b1bf8845726d0fadd70bbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated octave-compression to v3.0.0: introduced a tier-fidelity decision workflow, comprehensive loss-accounting and mandatory metadata guidelines, reworked transformation workflow with stronger validation and explicit loss receipts, tightened compression rules to preserve critical data (numbers/IDs/named entities), consolidated conservative techniques, and expanded anti-patterns to prevent silent or structural data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->