### PR TITLE
feat: add CONTEXT_MAINTENANCE delegation rule to ho-control-room

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
@@ -77,9 +77,14 @@ LEDGER:
     "Verify continuation_id health upon RESUMED state — FAULT if PAL rejects"
   ]
 
+CONTEXT_MAINTENANCE:
+  RULE::"All .hestai/state/context/*.oct.md files MUST be authored by octave-secretary. HO never writes context files directly."
+  TRIGGER::"After PR merge, after triage completion, after strategic directive ratification"
+  DISPATCH::"octave-secretary via oa-router with schema-context-archival pattern"
+
 DIRECT_WRITE_ALLOWED:
   ledger::.hestai/state/sessions/control-room-ledger.oct.md
-  coordination::".hestai/state/**/*.md"
+  coordination::".hestai/state/**/*.md[EXCEPT_context/*.oct.md→octave-secretary]"
   project_docs::[README.md, CLAUDE.md]
 
 BLOCKED_TOOLS::[NotebookEdit, MultiEdit, mcp__supabase__apply_migration, mcp__supabase__execute_sql, mcp__supabase__deploy_edge_function]
@@ -124,7 +129,8 @@ NEVER::[
   implement_production_code_directly,
   deep_dive_into_codebase_inline,
   waste_ho-liaison_session_on_trivial_questions,
-  delegate_without_ratified_directives_and_thresholds
+  delegate_without_ratified_directives_and_thresholds,
+  write_context_files_directly<delegate_to_octave-secretary>
 ]
 MUST::[
   checkpoint_ledger_before_returning_output_to_user,
@@ -134,7 +140,8 @@ MUST::[
   use_ho-liaison_wisely_before_pausing[session_dies_on_output],
   keep_first_clink_prompt_under_300_words_with_one_clear_question,
   store_continuation_id_in_ledger_after_every_pal_clink_call,
-  delegate_execution_via_oa-router_with_anchor_ceremony
+  delegate_execution_via_oa-router_with_anchor_ceremony,
+  delegate_context_file_updates_to_octave-secretary
 ]
 GATE::"Strategic decisions ratified in ledger? ho-liaison consulted? Execution delegated via oa-router? Zero HO code edits?"
 ===END===

--- a/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/ho-control-room/SKILL.md
@@ -79,12 +79,18 @@ LEDGER:
 
 CONTEXT_MAINTENANCE:
   RULE::"All .hestai/state/context/*.oct.md files MUST be authored by octave-secretary. HO never writes context files directly."
-  TRIGGER::"After PR merge, after triage completion, after strategic directive ratification"
+  TRIGGER::[
+    "After PR merge",
+    "After triage completion",
+    "After strategic directive ratification",
+    "Session close (via clock_out→octave-secretary): Context deltas are passed to octave-secretary, NOT written directly by HO"
+  ]
   DISPATCH::"octave-secretary via oa-router with schema-context-archival pattern"
 
 DIRECT_WRITE_ALLOWED:
   ledger::.hestai/state/sessions/control-room-ledger.oct.md
-  coordination::".hestai/state/**/*.md[EXCEPT_context/*.oct.md→octave-secretary]"
+  coordination::[".hestai/state/sessions/**/*", ".hestai/state/checklist/**/*"]
+  context_files_BLOCKED::".hestai/state/context/*.oct.md→octave-secretary_via_oa-router"
   project_docs::[README.md, CLAUDE.md]
 
 BLOCKED_TOOLS::[NotebookEdit, MultiEdit, mcp__supabase__apply_migration, mcp__supabase__execute_sql, mcp__supabase__deploy_edge_function]


### PR DESCRIPTION
## Summary
- Add CONTEXT_MAINTENANCE delegation rule to ho-control-room skill governance to enforce octave-secretary authorship of context files
- Update DIRECT_WRITE_ALLOWED coordination to exclude context files from HO direct writes
- Align V8 skill definition with V9 vault by adding context delegation constraints to ANCHOR_KERNEL

## Changes
- **§3::GOVERNANCE**: Added CONTEXT_MAINTENANCE block with rule, trigger, and dispatch configuration for context file management via octave-secretary
- **DIRECT_WRITE_ALLOWED coordination**: Updated to exclude `.hestai/state/context/*.oct.md` files, delegating to octave-secretary
- **§5::ANCHOR_KERNEL**: Added `write_context_files_directly<delegate_to_octave-secretary>` to NEVER list and `delegate_context_file_updates_to_octave-secretary` to MUST list

**Rationale**: HO control-room should trigger context updates but never author PROJECT-CONTEXT.oct.md or PROJECT-HISTORY.oct.md directly—octave-secretary has the octave-literacy and schema-context-archival pattern required for proper OCTAVE document authorship.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `CONTEXT_MAINTENANCE` rule to the `ho-control-room` skill to delegate context file authorship to `octave-secretary` and block HO writes. Strengthens enforcement with explicit path blocking and session-end routing.

- New Features
  - Added `CONTEXT_MAINTENANCE` with triggers (post-merge, post-triage, post-ratification, session close via clock_out) and dispatch to `octave-secretary` via `oa-router` using the schema-context-archival pattern.
  - Updated `DIRECT_WRITE_ALLOWED`: exclude `.hestai/state/context/*.oct.md`, add explicit `context_files_BLOCKED` routing to `octave-secretary` via `oa-router`, and narrow coordination whitelist to `.hestai/state/sessions/**/*` and `.hestai/state/checklist/**/*`.
  - In `ANCHOR_KERNEL`: added `write_context_files_directly<delegate_to_octave-secretary>` to NEVER and `delegate_context_file_updates_to_octave-secretary` to MUST.

<sup>Written for commit d45992e461c3955e48cef00484bfe5de031bb46c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

