### PR TITLE
refactor: remove bot dependencies and enhance review gate coverage

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -427,11 +427,6 @@ jobs:
 
       # AI code review bots (all advisory, non-blocking):
       # - Cubic Dev AI: auto-reviews on PR activity (no configuration available)
-      # - Qodo: auto-reviews on PR activity via GitHub App
-      #
-      # Post-gate workflow triggers were removed because:
-      # 1. Qodo: /review from github-actions[bot] works intermittently (first
-      #    trigger per PR only). Auto-reviews via GitHub App are more reliable.
-      # 2. Bot-to-bot comment triggers are unreliable across all providers.
+      # - GitHub Copilot: auto-reviews on PR activity
       #
       # The CRS/CE chain (via submit-review tool) remains the structural gate.

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -25,7 +25,6 @@ from typing import Any
 # convention; _BOT_LOGIN_SET is derived for comment filtering.
 ADVISORY_BOTS: list[str] = [
     "cubic-dev-ai[bot]",
-    "qodo-code-review[bot]",
     "github-copilot[bot]",
 ]
 
@@ -39,8 +38,6 @@ _BOT_LOGIN_SET: frozenset[str] = frozenset(
         "copilot",  # Legacy login variant for github-copilot[bot]
         "Copilot",  # GitHub API returns capital-C variant
         "cubic-bot",
-        "qodo-merge-pro",
-        "qodo-merge-pro-for-open-source",
     }
 )
 
@@ -133,7 +130,7 @@ def _is_generated_json(path: str) -> bool:
 # --- Facet → Required Reviewers mapping ---
 FACET_ROLE_MAP: dict[str, set[str]] = {
     "META_CONTROL_PLANE": {"CIV", "CE", "CRS", "SR", "TMG"},  # PE excluded: T4 is manual-only
-    "EXECUTABLE_SPEC": {"CE", "SR"},
+    "EXECUTABLE_SPEC": {"CE", "CRS", "SR"},
     "GOVERNANCE": {"SR"},
     "SECURITY": {"CIV", "CE", "CRS", "TMG"},
     "ROUTINE_CODE": {"CE", "CRS", "TMG"},

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -31,6 +31,9 @@ ADVISORY_BOTS: list[str] = [
 # --- Known bot account logins whose comments must be excluded from approval matching ---
 # Derived from ADVISORY_BOTS (strip "[bot]" suffix) plus legacy login variants
 # that GitHub may use for the same accounts.
+# NOTE: This set has a DIFFERENT lifecycle from ADVISORY_BOTS.  A bot removed
+# from ADVISORY_BOTS (e.g., Qodo) must STAY here so its comments can never
+# satisfy an approval gate — even if we no longer surface it in advisory output.
 _BOT_LOGIN_SET: frozenset[str] = frozenset(
     {name.removesuffix("[bot]") for name in ADVISORY_BOTS}
     | {
@@ -38,6 +41,9 @@ _BOT_LOGIN_SET: frozenset[str] = frozenset(
         "copilot",  # Legacy login variant for github-copilot[bot]
         "Copilot",  # GitHub API returns capital-C variant
         "cubic-bot",
+        "qodo-code-review",  # Removed from ADVISORY_BOTS but kept for gate exclusion
+        "qodo-merge-pro",
+        "qodo-merge-pro-for-open-source",
     }
 )
 

--- a/src/hestai_mcp/_bundled_hub/library/skills/review-context/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/review-context/SKILL.md
@@ -13,7 +13,7 @@ COMPLEMENTS::[review-preflight<context_collection>,review-discipline<confidence>
 §2::PATH_INSTRUCTIONS
 // Path-specific review focus areas.
 // CRS loads these instructions to calibrate review depth and focus per file type.
-// Transferred from CodeRabbit path_instructions (preserved domain knowledge).
+// CRS-native path instructions for calibrating review depth per file type.
 SOURCE_FILES::[
   PATHS::"src/**/*.py",
   FOCUS::[security,correctness,type_safety,error_handling],

--- a/src/hestai_mcp/_bundled_hub/library/skills/review-preflight/SKILL.md
+++ b/src/hestai_mcp/_bundled_hub/library/skills/review-preflight/SKILL.md
@@ -30,18 +30,15 @@ COLLECT::[
 // BOT_FINDINGS extraction protocol
 BOT_AUTHORS::[
   PRIORITY_1::cubic-dev-ai[bot]<structured_confidence⊕P0-P2_tiers⊕agent_prompts>,
-  PRIORITY_2::qodo-code-review[bot]<bug_classification⊕requirement_gaps>,
-  PRIORITY_3::github-copilot[bot]<inline_suggestions∧auto_review>
+  PRIORITY_2::github-copilot[bot]<inline_suggestions∧auto_review>
 ]
 // LOGIN_NORMALIZATION: GitHub APIs return different login formats for the same
 // bot accounts.  `gh pr view --json comments` returns logins WITHOUT the [bot]
-// suffix (e.g., "qodo-code-review"), while `gh api
+// suffix (e.g., "cubic-dev-ai"), while `gh api
 // repos/{owner}/{repo}/pulls/{pr}/comments` preserves the [bot] suffix (e.g.,
-// "cubic-dev-ai[bot]", "qodo-code-review[bot]").  Additionally, some bots use
-// legacy login variants that differ from their canonical name:
+// "cubic-dev-ai[bot]").  Additionally, some bots use legacy login variants
+// that differ from their canonical name:
 //   - github-copilot[bot] may appear as "Copilot" or "copilot" (no [bot] suffix)
-//   - qodo-code-review[bot] may appear as "qodo-merge-pro" or
-//     "qodo-merge-pro-for-open-source"
 //   - cubic-dev-ai[bot] may appear as "cubic-bot"
 //   - github-actions is the CI automation account (not a [bot]-suffixed account);
 //     its comments are excluded from gate validation because CI status comments
@@ -51,9 +48,8 @@ BOT_AUTHORS::[
 // comments, match against the normalized set, not the canonical names.
 BOT_EXTRACT::[
   SCAN_ISSUE_COMMENTS::"gh_pr_view_--json_comments→filter_by_normalized_BOT_LOGINS[strips_bot_suffix⊕includes_github-actions]",
-  SCAN_REVIEW_COMMENTS::"gh_api_repos/{repo}/pulls/{pr}/comments→filter_by_NORMALIZED_BOT_LOGINS[match_user.login_against:cubic-dev-ai|cubic-bot|qodo-code-review|qodo-merge-pro|qodo-merge-pro-for-open-source|github-copilot|Copilot|copilot|github-actions⊕also_match_[bot]_suffix]",
+  SCAN_REVIEW_COMMENTS::"gh_api_repos/{repo}/pulls/{pr}/comments→filter_by_NORMALIZED_BOT_LOGINS[match_user.login_against:cubic-dev-ai|cubic-bot|github-copilot|Copilot|copilot|github-actions⊕also_match_[bot]_suffix]",
   CUBIC::"extract_P0_P1_findings⊕confidence_metadata⊕agent_prompt_sections",
-  QODO::"extract_bug_findings⊕requirement_gap_findings",
   COPILOT::"extract_inline_suggestions[ADVISORY_context_only]",
   CLASSIFY::ADVISORY[bot_findings_NEVER_block_merge]
 ]

--- a/src/hestai_mcp/_bundled_hub/standards/rules/review-requirements.oct.md
+++ b/src/hestai_mcp/_bundled_hub/standards/rules/review-requirements.oct.md
@@ -16,8 +16,8 @@ META_CONTROL_PLANE::[
 ]
 EXECUTABLE_SPEC::[
   TRIGGER::".oct.md files with TYPE::AGENT_DEFINITION or TYPE::SKILL, or SKILL.md/pattern .md in bundled hub",
-  REQUIRED_REVIEWERS::"{CE, SR}",
-  RATIONALE::"Executable governance specs need both code and standards review"
+  REQUIRED_REVIEWERS::"{CE, CRS, SR}",
+  RATIONALE::"Executable governance specs need code quality, code review, and standards review"
 ]
 GOVERNANCE::[
   TRIGGER::".oct.md files with TYPE::RULE, TYPE::STANDARD, TYPE::NORTH_STAR_SUMMARY, or unknown type",

--- a/tests/unit/test_validate_review_5tier.py
+++ b/tests/unit/test_validate_review_5tier.py
@@ -1312,11 +1312,20 @@ class TestBotLoginSetNormalization:
         assert "github-copilot" in validate_review._BOT_LOGIN_SET
 
     def test_removed_bot_logins_absent(self) -> None:
-        """Removed bots (CodeRabbit, Qodo) must NOT be in _BOT_LOGIN_SET."""
+        """Fully removed bots (CodeRabbit) must NOT be in _BOT_LOGIN_SET."""
         assert "coderabbitai" not in validate_review._BOT_LOGIN_SET
-        assert "qodo-code-review" not in validate_review._BOT_LOGIN_SET
-        assert "qodo-merge-pro" not in validate_review._BOT_LOGIN_SET
-        assert "qodo-merge-pro-for-open-source" not in validate_review._BOT_LOGIN_SET
+
+    def test_decommissioned_bot_logins_still_excluded(self) -> None:
+        """Bots removed from ADVISORY_BOTS must STAY in _BOT_LOGIN_SET for gate exclusion.
+
+        _BOT_LOGIN_SET is a security filter: it prevents bot comments from
+        satisfying approval gates.  Even after a bot is removed from
+        ADVISORY_BOTS (no longer surfaced in advisory output), its logins must
+        remain excluded to prevent false-approval paths.
+        """
+        assert "qodo-code-review" in validate_review._BOT_LOGIN_SET
+        assert "qodo-merge-pro" in validate_review._BOT_LOGIN_SET
+        assert "qodo-merge-pro-for-open-source" in validate_review._BOT_LOGIN_SET
 
     def test_legacy_login_variants_present(self) -> None:
         """Legacy login variants must be in _BOT_LOGIN_SET."""
@@ -1371,6 +1380,44 @@ class TestPerVariantBotExclusion:
         monkeypatch.setattr(subprocess, "run", mock_run)
         approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
         assert approved is False, f"Cubic bot login '{login}' must NOT satisfy gate, got: {message}"
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "qodo-code-review",  # gh pr view format (no [bot])
+            "qodo-merge-pro",  # Legacy login variant
+            "qodo-merge-pro-for-open-source",  # Another legacy variant
+        ],
+    )
+    def test_qodo_variants_excluded(self, login, ci_environment, monkeypatch) -> None:
+        """Qodo bot comment variants must NOT satisfy approval gate.
+
+        Qodo was removed from ADVISORY_BOTS but its logins remain in
+        _BOT_LOGIN_SET as a security filter.  This test verifies that a
+        Qodo comment containing approval text is correctly rejected.
+        """
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": login},
+                                "body": "TMG APPROVED: tests ok\nCRS APPROVED: ok\nCE APPROVED: ok",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, f"Qodo bot login '{login}' must NOT satisfy gate, got: {message}"
 
     @pytest.mark.parametrize(
         "login",

--- a/tests/unit/test_validate_review_5tier.py
+++ b/tests/unit/test_validate_review_5tier.py
@@ -1281,17 +1281,17 @@ class TestAdvisoryBotsConstant:
     def test_advisory_bots_contains_expected_entries(self) -> None:
         """ADVISORY_BOTS must contain all canonical bot accounts."""
         assert "cubic-dev-ai[bot]" in validate_review.ADVISORY_BOTS
-        assert "qodo-code-review[bot]" in validate_review.ADVISORY_BOTS
         assert "github-copilot[bot]" in validate_review.ADVISORY_BOTS
 
     def test_advisory_bots_does_not_contain_removed_bots(self) -> None:
-        """ADVISORY_BOTS must NOT contain removed bot accounts (CodeRabbit)."""
+        """ADVISORY_BOTS must NOT contain removed bot accounts (CodeRabbit, Qodo)."""
         assert "coderabbitai[bot]" not in validate_review.ADVISORY_BOTS
+        assert "qodo-code-review[bot]" not in validate_review.ADVISORY_BOTS
 
     def test_advisory_bots_length(self) -> None:
-        """ADVISORY_BOTS should have exactly 3 entries (detect unintended additions)."""
-        assert len(validate_review.ADVISORY_BOTS) == 3, (
-            f"Expected 3 advisory bots, got {len(validate_review.ADVISORY_BOTS)}: "
+        """ADVISORY_BOTS should have exactly 2 entries (detect unintended additions)."""
+        assert len(validate_review.ADVISORY_BOTS) == 2, (
+            f"Expected 2 advisory bots, got {len(validate_review.ADVISORY_BOTS)}: "
             f"{validate_review.ADVISORY_BOTS}"
         )
 
@@ -1309,20 +1309,20 @@ class TestBotLoginSetNormalization:
     def test_stripped_bot_suffix_logins_present(self) -> None:
         """Stripped versions of ADVISORY_BOTS must be in _BOT_LOGIN_SET."""
         assert "cubic-dev-ai" in validate_review._BOT_LOGIN_SET
-        assert "qodo-code-review" in validate_review._BOT_LOGIN_SET
         assert "github-copilot" in validate_review._BOT_LOGIN_SET
 
     def test_removed_bot_logins_absent(self) -> None:
-        """Removed bots (CodeRabbit) must NOT be in _BOT_LOGIN_SET."""
+        """Removed bots (CodeRabbit, Qodo) must NOT be in _BOT_LOGIN_SET."""
         assert "coderabbitai" not in validate_review._BOT_LOGIN_SET
+        assert "qodo-code-review" not in validate_review._BOT_LOGIN_SET
+        assert "qodo-merge-pro" not in validate_review._BOT_LOGIN_SET
+        assert "qodo-merge-pro-for-open-source" not in validate_review._BOT_LOGIN_SET
 
     def test_legacy_login_variants_present(self) -> None:
         """Legacy login variants must be in _BOT_LOGIN_SET."""
         assert "github-actions" in validate_review._BOT_LOGIN_SET
         assert "copilot" in validate_review._BOT_LOGIN_SET  # Copilot legacy login
         assert "cubic-bot" in validate_review._BOT_LOGIN_SET
-        assert "qodo-merge-pro" in validate_review._BOT_LOGIN_SET
-        assert "qodo-merge-pro-for-open-source" in validate_review._BOT_LOGIN_SET
 
     def test_bot_login_set_is_frozenset(self) -> None:
         """_BOT_LOGIN_SET must be immutable (frozenset)."""
@@ -1371,39 +1371,6 @@ class TestPerVariantBotExclusion:
         monkeypatch.setattr(subprocess, "run", mock_run)
         approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
         assert approved is False, f"Cubic bot login '{login}' must NOT satisfy gate, got: {message}"
-
-    @pytest.mark.parametrize(
-        "login",
-        [
-            "qodo-code-review",  # gh pr view format (no [bot])
-            "qodo-merge-pro",  # Legacy login variant
-            "qodo-merge-pro-for-open-source",  # Another legacy variant
-        ],
-    )
-    def test_qodo_variants_excluded(self, login, ci_environment, monkeypatch) -> None:
-        """Qodo bot comment variants must NOT satisfy approval gate."""
-        import subprocess
-
-        def mock_run(cmd, *args, **kwargs):
-            return MagicMock(
-                stdout=json.dumps(
-                    {
-                        "body": "",
-                        "comments": [
-                            {
-                                "author": {"login": login},
-                                "body": "TMG APPROVED: tests ok\nCRS APPROVED: ok\nCE APPROVED: ok",
-                            },
-                        ],
-                    }
-                ),
-                returncode=0,
-                check=lambda: None,
-            )
-
-        monkeypatch.setattr(subprocess, "run", mock_run)
-        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
-        assert approved is False, f"Qodo bot login '{login}' must NOT satisfy gate, got: {message}"
 
     @pytest.mark.parametrize(
         "login",
@@ -1459,8 +1426,8 @@ class TestSkippedBotLogging:
                         "body": "",
                         "comments": [
                             {
-                                "author": {"login": "qodo-code-review"},
-                                "body": "Some review text",
+                                "author": {"login": "github-copilot"},
+                                "body": "Some copilot review text",
                             },
                             {
                                 "author": {"login": "cubic-dev-ai"},
@@ -1485,8 +1452,8 @@ class TestSkippedBotLogging:
             "Skipped 2 bot comment(s)" in captured.out
         ), f"Expected 'Skipped 2 bot comment(s)' in output, got: {captured.out}"
         assert (
-            "qodo-code-review" in captured.out
-        ), f"Expected 'qodo-code-review' in skipped bot names, got: {captured.out}"
+            "github-copilot" in captured.out
+        ), f"Expected 'github-copilot' in skipped bot names, got: {captured.out}"
         assert (
             "cubic-dev-ai" in captured.out
         ), f"Expected 'cubic-dev-ai' in skipped bot names, got: {captured.out}"

--- a/tests/unit/test_validate_review_facets.py
+++ b/tests/unit/test_validate_review_facets.py
@@ -149,8 +149,8 @@ class TestFacetClassification:
         facets, roles, tier, _ = validate_review.classify_pr_facets(files)
         assert tier == "TIER_0_EXEMPT", f"Regular .md should be exempt, got {tier}"
 
-    def test_skill_pr_requires_ce_sr_review(self) -> None:
-        """A PR with only SKILL.md files must require CE+SR (EXECUTABLE_SPEC)."""
+    def test_skill_pr_requires_ce_crs_sr_review(self) -> None:
+        """A PR with only SKILL.md files must require CE+CRS+SR (EXECUTABLE_SPEC)."""
         files = [
             {
                 "path": "src/hestai_mcp/_bundled_hub/library/skills/build-execution/SKILL.md",
@@ -176,6 +176,95 @@ class TestFacetClassification:
         facets, roles, tier, _ = validate_review.classify_pr_facets(files)
         assert "SR" in roles, f"Mixed PR should require SR for .oct.md, got {roles}"
         assert "CRS" in roles, f"Mixed PR should require CRS for .py, got {roles}"
+
+
+# ---------------------------------------------------------------------------
+# 1b. Functional EXECUTABLE_SPEC gate tests
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestExecutableSpecGateRequiresCRS:
+    """EXECUTABLE_SPEC PRs must fail the gate without CRS approval.
+
+    Since CRS was added to the EXECUTABLE_SPEC facet reviewer set, a PR
+    touching only agent/skill files must require CRS APPROVED alongside
+    CE and SR.  This functional test calls check_pr_comments() to verify
+    the gate rejects when CRS is missing.
+    """
+
+    @pytest.fixture(autouse=True)
+    def ci_environment(self, monkeypatch):
+        """Set CI + PR_NUMBER so check_pr_comments runs its full logic."""
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv("PR_NUMBER", "999")
+
+    def test_executable_spec_fails_without_crs(self, monkeypatch) -> None:
+        """EXECUTABLE_SPEC gate must reject when CRS approval is missing."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "human-ce"},
+                                "body": "CE APPROVED: code looks good",
+                            },
+                            {
+                                "author": {"login": "human-sr"},
+                                "body": "SR APPROVED: standards met",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        # EXECUTABLE_SPEC requires {CE, CRS, SR} — CE and SR present, CRS missing
+        approved, message, missing = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "SR"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is False, f"Should fail without CRS, got: {message}"
+        assert "CRS" in missing, f"CRS should be in missing roles, got: {missing}"
+
+    def test_executable_spec_passes_with_all_roles(self, monkeypatch) -> None:
+        """EXECUTABLE_SPEC gate must pass when CE, CRS, and SR all approve."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "human-ce"},
+                                "body": "CE APPROVED: code looks good",
+                            },
+                            {
+                                "author": {"login": "human-crs"},
+                                "body": "CRS APPROVED: review complete",
+                            },
+                            {
+                                "author": {"login": "human-sr"},
+                                "body": "SR APPROVED: standards met",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        approved, message, missing = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "SR"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is True, f"Should pass with all roles, got: {message}"
+        assert missing == [], f"No roles should be missing, got: {missing}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_validate_review_facets.py
+++ b/tests/unit/test_validate_review_facets.py
@@ -60,7 +60,7 @@ class TestFacetClassification:
         assert "SR" in roles, f"Governance file should require SR, got {roles}"
 
     def test_octave_agent_is_executable_spec(self) -> None:
-        """.oct.md TYPE::AGENT_DEFINITION -> EXECUTABLE_SPEC facet -> {CE, SR}."""
+        """.oct.md TYPE::AGENT_DEFINITION -> EXECUTABLE_SPEC facet -> {CE, CRS, SR}."""
         files = [
             {
                 "path": "src/hestai_mcp/_bundled_hub/library/agents/implementation-lead.oct.md",
@@ -72,6 +72,7 @@ class TestFacetClassification:
         facets, roles, tier, _ = validate_review.classify_pr_facets(files)
         assert "EXECUTABLE_SPEC" in facets, f"Agent .oct.md should be EXECUTABLE_SPEC, got {facets}"
         assert "CE" in roles, f"Agent def should require CE, got {roles}"
+        assert "CRS" in roles, f"Agent def should require CRS, got {roles}"
         assert "SR" in roles, f"Agent def should require SR, got {roles}"
 
     def test_security_path_includes_civ(self) -> None:
@@ -118,7 +119,9 @@ class TestFacetClassification:
         ]
         facets, roles, tier, _ = validate_review.classify_pr_facets(files)
         assert "EXECUTABLE_SPEC" in facets, f"SKILL.md should be EXECUTABLE_SPEC, got {facets}"
-        assert "CE" in roles and "SR" in roles, f"SKILL.md needs CE+SR, got {roles}"
+        assert (
+            "CE" in roles and "CRS" in roles and "SR" in roles
+        ), f"SKILL.md needs CE+CRS+SR, got {roles}"
         assert tier != "TIER_0_EXEMPT", f"SKILL.md must NOT be exempt, got {tier}"
 
     def test_pattern_md_is_executable_spec(self) -> None:
@@ -157,7 +160,7 @@ class TestFacetClassification:
             },
         ]
         facets, roles, tier, _ = validate_review.classify_pr_facets(files)
-        assert roles == {"CE", "SR"}, f"Skill PR should need CE+SR, got {roles}"
+        assert roles == {"CE", "CRS", "SR"}, f"Skill PR should need CE+CRS+SR, got {roles}"
 
     def test_mixed_code_and_governance(self) -> None:
         """Mixed .py + .oct.md -> union of ROUTINE_CODE + GOVERNANCE roles."""


### PR DESCRIPTION
## Summary
- Eliminated CodeRabbit/Qodo bot dependency from review-gate workflow to reduce external service coupling
- Enriched CRS coverage for governance files including review requirements and skill documentation
- Simplified validation logic while maintaining review gate integrity

## Changes
- **Workflow & Validation**: Removed bot-dependent checks from `.github/workflows/review-gate.yml` and updated `scripts/validate_review.py` to reflect streamlined gate logic
- **Documentation & Standards**: Updated review-context and review-preflight skill definitions, refined review-requirements.oct.md governance rules for clarity
- **Test Coverage**: Consolidated unit tests in `test_validate_review_5tier.py` and `test_validate_review_facets.py` to remove bot-related test cases and focus on core validation patterns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Qodo/CodeRabbit dependency from the review gate and expanded `CRS` coverage to executable governance specs. Also fixed a false-approval path by keeping Qodo logins in the gate’s bot-exclusion filter.

- **New Features**
  - Added `CRS` to the `EXECUTABLE_SPEC` reviewer set (now `CE+CRS+SR`) for agent/skill/pattern `.md` files; updated rules and facet tests.

- **Refactors**
  - Removed `qodo-code-review[bot]` from `ADVISORY_BOTS`, `review-preflight`, and workflow comments; advisory bots are now `cubic-dev-ai[bot]` and `github-copilot[bot]`. Updated `review-context` to use CRS-native path instructions and aligned tests.

- **Bug Fixes**
  - Retained Qodo logins (`qodo-code-review`, `qodo-merge-pro*`) in `_BOT_LOGIN_SET` so their comments never satisfy approvals; added functional tests for Qodo rejection and for `EXECUTABLE_SPEC` requiring `CE+CRS+SR`.

<sup>Written for commit ac8e26e0820133f03af4f9b6557088766d7eb2e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed legacy bot entries from review automation and added GitHub Copilot as an advisory auto-reviewer.
* **Bug Fixes**
  * Increased required reviewer roles for executable-spec PRs to include an additional code-review role, affecting required approvals.
* **Tests**
  * Updated and added unit tests to reflect bot-list and reviewer-role changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->