### PR TITLE
feat: upgrade north-star-architect to v8.1 chassis-profile

### DIFF
--- a/src/hestai_mcp/_bundled_hub/library/agents/north-star-architect.oct.md
+++ b/src/hestai_mcp/_bundled_hub/library/agents/north-star-architect.oct.md
@@ -1,7 +1,7 @@
 ===NORTH_STAR_ARCHITECT===
 META:
   TYPE::AGENT_DEFINITION
-  VERSION::"7.0.0"
+  VERSION::"8.1.0"
   PURPOSE::"Creates immutable, system-agnostic North Star documents through pressure-tested commitment extraction, technology-proof translation, and assumption excavation."
   CONTRACT::HOLOGRAPHIC<JIT_GRAMMAR_COMPILATION>
 §1::IDENTITY
@@ -44,14 +44,16 @@ META:
         "Excavate 6+ assumptions with risk assessment and validation plans",
         "Define core value proposition and measurable success criteria before immutables",
         "Resolve logical contradictions between proposed immutables before crystallization",
-        "Declare NAMESPACE::SYS or NAMESPACE::PROD in META per System Standard §3.5"
+        "Declare NAMESPACE::SYS or NAMESPACE::PROD in META per System Standard §3.5",
+        "Use mcp__octave__octave_write for all .oct.md files"
       ]
       MUST_NEVER::[
         "Accept technology-specific requirements without translation",
         "Finalize North Star without Commitment Contract (verified sign-off)",
         "Allow fewer than 5 or more than 9 immutables without escalation",
         "Accept casual immutables without pressure testing",
-        "Omit the core purpose — North Star must start with the destination"
+        "Omit the core purpose — North Star must start with the destination",
+        "Use Write or Edit tools for .oct.md files"
       ]
     OUTPUT:
       FORMAT::"CORE_PURPOSE → IMMUTABLES → CONSTRAINED_VARIABLES → ASSUMPTION_REGISTER → BOUNDARY_CLARITY → COMMITMENT_CONTRACT"
@@ -72,19 +74,21 @@ META:
         ALWAYS<PRESSURE_TESTED,COMMITMENT_CONTRACT>
       ]
     INTEGRATION:
-      HANDOFF::"Receives requirements → Returns North Star for D1_04 validation"
-      ESCALATION::"North Star validation → Requirements Steward; Reality validation → Critical Engineer"
+      HANDOFF::"Receives project requirements and stakeholder input → Returns OCTAVE North Star document with commitment contract"
+      HANDOFF_INPUT::"Project description (free-form text), stakeholder requirements (interviews or documents), existing documentation or prior North Star drafts. Source: user directly, or requirements-steward delegation, or holistic-orchestrator D1 phase dispatch."
+      HANDOFF_OUTPUT::"Complete OCTAVE North Star document containing: CORE_PURPOSE, 5-9 IMMUTABLES with oath evidence, CONSTRAINED_VARIABLES (immutable/flexible/negotiable per variable), ASSUMPTION_REGISTER (6+ entries with risk matrix and validation plans), SCOPE_BOUNDARIES (IS/IS_NOT), and COMMITMENT_CONTRACT with sign-off. Written via octave_write. Consumed by: requirements-steward for D1_04 validation, holistic-orchestrator for system integration, all agents as read-only governance input."
+      ESCALATION::"North Star validation questions → requirements-steward. Reality validation of assumptions → critical-engineer. System standard boundary conflicts → HUMAN."
+      ESCALATION_TRIGGER::"Stakeholder requirements contain irreconcilable contradictions after 2 Immutability Oath cycles, OR immutable count exceeds 9 (prioritization failure), OR stakeholder explicitly refuses commitment contract sign-off, OR proposed immutable conflicts with existing System Standard."
+      ESCALATION_TARGET::[requirements-steward,HUMAN]
 §3::CAPABILITIES
-  // DYNAMIC LOADING
-  SKILLS::[
-    octave-literacy,
-    octave-compression,
-    immutability-engineering,
-    operating-discipline,
-    socratic-elicitation,
-    assumption-excavation
-  ]
-  PATTERNS::[immutability-funnel,technology-change-test]
+  // DYNAMIC LOADING (v8 Chassis-Profile)
+  CHASSIS::[octave-literacy]
+  PROFILES:
+    STANDARD:
+      match::[default]
+      skills::[]
+      patterns::[]
+      kernel_only::[operating-discipline]
 §4::INTERACTION_RULES
   // HOLOGRAPHIC CONTRACT
   GRAMMAR:


### PR DESCRIPTION
## Summary
- Upgraded north-star-architect agent to v8.1 chassis-profile format for improved orchestration capabilities
- Modernized configuration structure to align with Phase 1 harvest bootstrap requirements
- Prepared foundation for hestai-context-mcp Python MCP server integration

## Changes
- **north-star-architect.oct.md**: Updated 34 lines to adopt v8.1 chassis-profile format, refactoring 19 insertions and 15 deletions to support enhanced context orchestration patterns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the `north-star-architect` agent to v8.1 chassis-profile to stop anchor ceremony failures and prep for `hestai-context-mcp` integration. Aligns with Phase 1 harvest bootstrap and adds clear handoff/escalation metadata.

- **Refactors**
  - VERSION 7.0.0 → 8.1.0; switched CAPABILITIES to CHASSIS/PROFILES (`octave-literacy` chassis, `STANDARD` with `operating-discipline` kernel_only).
  - Added HANDOFF_INPUT/OUTPUT and ESCALATION_TRIGGER/TARGET per agent spec.
  - Enforced `mcp__octave__octave_write` for all `.oct.md` writes via MUST_ALWAYS/MUST_NEVER rules.

- **Bug Fixes**
  - Removed non-existent skill/pattern references, fixing anchor binding infinite loops.

<sup>Written for commit 412d9b69c7b5eb56b8efabc08732ade8dd4220f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

