### PR TITLE
feat(canonical-paths): add META.CANONICAL/SOURCE validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
             echo "SKIP canonical-paths (no .oct.md changes)"
             exit 0
           fi
-          xargs -a changed_octave.txt python scripts/ci/validate_canonical_paths.py
+          while IFS= read -r f; do
+            python scripts/ci/validate_canonical_paths.py "$f"
+          done < changed_octave.txt
 
       - name: Validate naming/visibility for changed docs
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,16 @@ jobs:
             python src/hestai_mcp/_bundled_hub/tools/octave-validator.py --profile protocol "$f"
           done < changed_octave.txt
 
+      - name: Validate canonical paths for changed .oct.md
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.diff.outputs.changed_octave_count }}" = "0" ]; then
+            echo "SKIP canonical-paths (no .oct.md changes)"
+            exit 0
+          fi
+          xargs -a changed_octave.txt python scripts/ci/validate_canonical_paths.py
+
       - name: Validate naming/visibility for changed docs
         shell: bash
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 
       - id: canonical-paths-validate
         name: Validate canonical paths for staged .oct.md
-        entry: bash -c 'set -euo pipefail; files="$(git diff --cached --name-only --diff-filter=ACMR | grep -E "\\.oct\\.md$" || true)"; if [ -z "$files" ]; then echo "SKIP canonical-paths (no .oct.md staged)"; exit 0; fi; echo "$files" | xargs python3 scripts/ci/validate_canonical_paths.py'
+        entry: bash -c 'set -euo pipefail; files="$(git diff --cached -z --name-only --diff-filter=ACMR | tr "\0" "\n" | grep -E "\\.oct\\.md$" || true)"; if [ -z "$files" ]; then echo "SKIP canonical-paths (no .oct.md staged)"; exit 0; fi; echo "$files" | xargs python3 scripts/ci/validate_canonical_paths.py'
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 
       - id: canonical-paths-validate
         name: Validate canonical paths for staged .oct.md
-        entry: bash -c 'set -euo pipefail; files="$(git diff --cached -z --name-only --diff-filter=ACMR | tr "\0" "\n" | grep -E "\\.oct\\.md$" || true)"; if [ -z "$files" ]; then echo "SKIP canonical-paths (no .oct.md staged)"; exit 0; fi; echo "$files" | xargs python3 scripts/ci/validate_canonical_paths.py'
+        entry: python3 scripts/ci/validate_canonical_paths.py --staged
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
         pass_filenames: false
         always_run: true
 
+      - id: canonical-paths-validate
+        name: Validate canonical paths for staged .oct.md
+        entry: bash -c 'set -euo pipefail; files="$(git diff --cached --name-only --diff-filter=ACMR | grep -E "\\.oct\\.md$" || true)"; if [ -z "$files" ]; then echo "SKIP canonical-paths (no .oct.md staged)"; exit 0; fi; echo "$files" | xargs python3 scripts/ci/validate_canonical_paths.py'
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: naming-visibility-validate
         name: Validate naming/visibility for staged docs
         entry: python3 scripts/ci/validate_naming_visibility.py --staged

--- a/scripts/ci/validate_canonical_paths.py
+++ b/scripts/ci/validate_canonical_paths.py
@@ -31,8 +31,9 @@ _RE_FIELD = re.compile(
 
 # Captures the META block: everything after "META:\n" up to (but not
 # including) the first section marker (§) or document end (===).
+# Allows blank lines within the block (authors sometimes add them for readability).
 _RE_META_BLOCK = re.compile(
-    r"^META:\s*\n((?:(?!§|===)[ \t][^\n]*\n)*)",
+    r"^META:\s*\n((?:(?!§|===)(?:[ \t][^\n]*|\s*)\n)*)",
     re.MULTILINE,
 )
 
@@ -75,14 +76,15 @@ def _git_repo_root() -> Path:
 
 def _staged_oct_md_files() -> list[str]:
     result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR"],
         capture_output=True,
         text=True,
         check=False,
     )
     if result.returncode != 0:
         raise SystemExit("ERROR canonical-paths: git diff --cached failed")
-    return [line.strip() for line in result.stdout.splitlines() if line.strip().endswith(".oct.md")]
+    # -z outputs NUL-separated paths; handles filenames with spaces correctly
+    return [f for f in result.stdout.split("\0") if f.endswith(".oct.md")]
 
 
 def _validate_file(file_path: str, repo_root: Path) -> str | None:
@@ -115,8 +117,7 @@ def _validate_file(file_path: str, repo_root: Path) -> str | None:
     for value in (canonical, source):
         if not value:
             continue
-        # Only treat values that look like paths (contain /)
-        if "/" in value and _normalize_path(value) == file_norm:
+        if _normalize_path(value) == file_norm:
             return None
 
     declared: list[str] = []

--- a/scripts/ci/validate_canonical_paths.py
+++ b/scripts/ci/validate_canonical_paths.py
@@ -63,24 +63,30 @@ def _normalize_path(raw: str) -> str:
 
 
 def _git_repo_root() -> Path:
-    result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise SystemExit("ERROR canonical-paths: git not found in PATH") from None
     if result.returncode != 0:
         raise SystemExit("ERROR canonical-paths: not in a git repository")
     return Path(result.stdout.strip())
 
 
 def _staged_oct_md_files() -> list[str]:
-    result = subprocess.run(
-        ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise SystemExit("ERROR canonical-paths: git not found in PATH") from None
     if result.returncode != 0:
         raise SystemExit("ERROR canonical-paths: git diff --cached failed")
     # -z outputs NUL-separated paths; handles filenames with spaces correctly

--- a/scripts/ci/validate_canonical_paths.py
+++ b/scripts/ci/validate_canonical_paths.py
@@ -1,0 +1,188 @@
+"""Validate META.CANONICAL / META.SOURCE paths in staged .oct.md files.
+
+Every committed .oct.md must declare at least one of:
+  CANONICAL::"<repo-relative-path>"  — the file's own path (or deployed path)
+  SOURCE::"<repo-relative-path>"     — the authored source path
+
+At least one declared value must match the file's actual repo-relative posix
+path (normalised, leading ./ stripped).
+
+Bypass: SOURCE::legacy or CANONICAL::legacy exempts a file pending cleanup.
+
+Exit 0 — all files pass.
+Exit 1 — one or more files fail; all errors printed to stderr before exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+# Matches CANONICAL or SOURCE in the META block.
+# Handles quoted ("value") and unquoted (value) forms, trailing commas,
+# and optional inline comments.
+_RE_FIELD = re.compile(
+    r"""^\s*(?P<field>CANONICAL|SOURCE)::[ \t]*(?:"(?P<qval>[^"\n]*)"|\s*(?P<uval>[^\s,#\n][^,#\n]*?))[ \t]*,?[ \t]*(?:#[^\n]*)?\s*$""",
+    re.MULTILINE,
+)
+
+# Captures the META block: everything after "META:\n" up to (but not
+# including) the first section marker (§) or document end (===).
+_RE_META_BLOCK = re.compile(
+    r"^META:\s*\n((?:(?!§|===)[ \t][^\n]*\n)*)",
+    re.MULTILINE,
+)
+
+
+def _extract_meta_fields(content: str) -> dict[str, str]:
+    """Return CANONICAL and SOURCE values from the META block, if present."""
+    meta_match = _RE_META_BLOCK.search(content)
+    if not meta_match:
+        return {}
+
+    meta_block = meta_match.group(1)
+    fields: dict[str, str] = {}
+    for m in _RE_FIELD.finditer(meta_block):
+        field = m.group("field")
+        value = m.group("qval") if m.group("qval") is not None else m.group("uval")
+        if value is not None:
+            fields[field] = value.strip()
+    return fields
+
+
+def _normalize_path(raw: str) -> str:
+    """Normalise a path for comparison: strip leading ./ prefix only."""
+    s = raw.strip()
+    if s.startswith("./"):
+        s = s[2:]
+    return str(PurePosixPath(s))
+
+
+def _git_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit("ERROR canonical-paths: not in a git repository")
+    return Path(result.stdout.strip())
+
+
+def _staged_oct_md_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit("ERROR canonical-paths: git diff --cached failed")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip().endswith(".oct.md")]
+
+
+def _validate_file(file_path: str, repo_root: Path) -> str | None:
+    """Validate one .oct.md file.
+
+    Returns None on success, or an error string describing the failure.
+    """
+    abs_path = (repo_root / file_path).resolve()
+    try:
+        content = abs_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return f"FAIL {file_path}: cannot read file — {exc}"
+
+    fields = _extract_meta_fields(content)
+    canonical = fields.get("CANONICAL", "").strip()
+    source = fields.get("SOURCE", "").strip()
+
+    # Legacy bypass — file is pending proper annotation
+    if canonical.lower() == "legacy" or source.lower() == "legacy":
+        return None
+
+    if not canonical and not source:
+        return (
+            f"FAIL {file_path}: missing META.CANONICAL and META.SOURCE.\n"
+            f'  Add  SOURCE::"{file_path}"  or  SOURCE::legacy  (pending cleanup).'
+        )
+
+    file_norm = _normalize_path(file_path)
+
+    for value in (canonical, source):
+        if not value:
+            continue
+        # Only treat values that look like paths (contain /)
+        if "/" in value and _normalize_path(value) == file_norm:
+            return None
+
+    declared: list[str] = []
+    if canonical:
+        declared.append(f"CANONICAL::{canonical!r}")
+    if source:
+        declared.append(f"SOURCE::{source!r}")
+
+    return (
+        f"FAIL {file_path}: declared path(s) do not match file location.\n"
+        f"  File is at: {file_norm}\n"
+        f"  Declared:   {', '.join(declared)}\n"
+        f"  Fix: update the declared path or add SOURCE::legacy to bypass."
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate META.CANONICAL/SOURCE paths in .oct.md files.",
+    )
+    parser.add_argument(
+        "--staged",
+        action="store_true",
+        help="Validate staged .oct.md files (from git index).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Repository root (defaults to git rev-parse --show-toplevel).",
+    )
+    parser.add_argument("paths", nargs="*", help=".oct.md file paths to check.")
+    args = parser.parse_args(argv)
+
+    files: list[str] = list(args.paths)
+    if args.staged:
+        files = _staged_oct_md_files()
+
+    # Filter to .oct.md only (positional args may include other files)
+    files = [f for f in files if f.endswith(".oct.md")]
+
+    if not files:
+        print("SKIP canonical-paths (no .oct.md files to check)")
+        return 0
+
+    repo_root: Path = args.repo_root or _git_repo_root()
+
+    errors: list[str] = []
+    for file_path in files:
+        error = _validate_file(file_path, repo_root)
+        if error:
+            errors.append(error)
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        print(
+            f"FAIL canonical-paths: {len(errors)}/{len(files)} file(s) failed",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK canonical-paths: {len(files)} file(s) validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/scripts/test_validate_canonical_paths.py
+++ b/tests/unit/scripts/test_validate_canonical_paths.py
@@ -1,0 +1,250 @@
+"""Tests for scripts/ci/validate_canonical_paths.py.
+
+TDD RED phase: written before the implementation exists.
+
+Behaviour contract:
+- Exit 0 when all staged .oct.md files have a META.CANONICAL or META.SOURCE
+  whose value matches the file's repo-relative path (normalised posix).
+- Exit 0 when SOURCE::legacy or CANONICAL::legacy is declared (bypass for
+  files pending cleanup).
+- Exit 1 when any file declares neither field, or the declared value does
+  not match the file's actual location.
+- Non-.oct.md files passed as positional args are silently ignored.
+- Exit 0 with SKIP message when no .oct.md files are found.
+- All failures are reported together (not fail-fast on first error).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_oct_md(root: Path, rel_path: str, meta_lines: str) -> Path:
+    """Create a minimal .oct.md file with the given META body under root."""
+    file = root / rel_path
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(
+        f"===DOC===\nMETA:\n{meta_lines}\n§1::CONTENT\n  VALUE::test\n===END===\n",
+        encoding="utf-8",
+    )
+    return file
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateCanonicalPaths:
+    """Unit tests for validate_canonical_paths.main() and helpers."""
+
+    # ------------------------------------------------------------------
+    # PASS cases
+    # ------------------------------------------------------------------
+
+    def test_pass_matching_source_quoted(self, tmp_path: Path) -> None:
+        """SOURCE with quoted value matching repo-relative path → pass."""
+        rel = "src/hestai_mcp/_bundled_hub/standards/rules/some-rule.oct.md"
+        _write_oct_md(tmp_path, rel, f'  SOURCE::"{rel}"\n')
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_pass_matching_canonical_unquoted(self, tmp_path: Path) -> None:
+        """CANONICAL without quotes matching repo-relative path → pass."""
+        rel = ".hestai/rules/hub-authoring-rules.oct.md"
+        _write_oct_md(tmp_path, rel, f"  CANONICAL::{rel}\n")
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_pass_source_legacy_unquoted(self, tmp_path: Path) -> None:
+        """SOURCE::legacy (unquoted) bypasses validation."""
+        rel = "debates/2025-12-24-old-debate.oct.md"
+        _write_oct_md(tmp_path, rel, "  SOURCE::legacy\n")
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_pass_source_legacy_quoted(self, tmp_path: Path) -> None:
+        """SOURCE::"legacy" (quoted) also bypasses validation."""
+        rel = "debates/2025-12-24-old-debate.oct.md"
+        _write_oct_md(tmp_path, rel, '  SOURCE::"legacy"\n')
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_pass_canonical_legacy(self, tmp_path: Path) -> None:
+        """CANONICAL::legacy bypasses validation."""
+        rel = "src/hestai_mcp/_bundled_hub/library/agents/old.oct.md"
+        _write_oct_md(tmp_path, rel, "  CANONICAL::legacy\n")
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_pass_canonical_deployed_source_matches(self, tmp_path: Path) -> None:
+        """bundled_hub file: CANONICAL points to .hestai-sys/ (deployed),
+        SOURCE matches actual file path → pass (at least one field matches)."""
+        rel = "src/hestai_mcp/_bundled_hub/standards/rules/visibility-rules.oct.md"
+        meta = (
+            '  CANONICAL::".hestai-sys/standards/rules/visibility-rules.oct.md"\n'
+            f'  SOURCE::"{rel}"\n'
+        )
+        _write_oct_md(tmp_path, rel, meta)
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_pass_dot_slash_prefix_in_value(self, tmp_path: Path) -> None:
+        """SOURCE::"./src/foo/bar.oct.md" normalises to src/foo/bar.oct.md → pass."""
+        rel = "src/foo/bar.oct.md"
+        _write_oct_md(tmp_path, rel, '  SOURCE::"./src/foo/bar.oct.md"\n')
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_skip_non_oct_md_files(self, tmp_path: Path) -> None:
+        """Non-.oct.md files passed as positional args are ignored."""
+        md = tmp_path / "docs" / "guide.md"
+        md.parent.mkdir(parents=True)
+        md.write_text("# Guide\n")
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), "docs/guide.md"]) == 0
+
+    def test_empty_file_list_passes(self, tmp_path: Path) -> None:
+        """No files → exit 0 with SKIP message."""
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path)]) == 0
+
+    # ------------------------------------------------------------------
+    # FAIL cases
+    # ------------------------------------------------------------------
+
+    def test_fail_no_canonical_no_source(self, tmp_path: Path) -> None:
+        """File with no CANONICAL or SOURCE → fail."""
+        rel = "src/hestai_mcp/_bundled_hub/library/agents/agent.oct.md"
+        _write_oct_md(tmp_path, rel, '  TYPE::AGENT_DEFINITION\n  VERSION::"1.0"\n')
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 1
+
+    def test_fail_source_wrong_path(self, tmp_path: Path) -> None:
+        """SOURCE declared but doesn't match file's actual path → fail."""
+        rel = "src/foo/actual.oct.md"
+        _write_oct_md(tmp_path, rel, '  SOURCE::"src/foo/wrong-name.oct.md"\n')
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 1
+
+    def test_fail_canonical_wrong_path(self, tmp_path: Path) -> None:
+        """CANONICAL declared but doesn't match file's actual path (and no SOURCE) → fail."""
+        rel = ".hestai/rules/rule.oct.md"
+        _write_oct_md(tmp_path, rel, '  CANONICAL::".hestai/rules/other-rule.oct.md"\n')
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 1
+
+    def test_fail_semantic_source_no_canonical(self, tmp_path: Path) -> None:
+        """Debate file with SOURCE as content provenance (not a path) → fail."""
+        rel = "debates/2025-12-24-some-debate.oct.md"
+        _write_oct_md(tmp_path, rel, "  SOURCE::system_steward_analysis+LLM_research[2025-12-18]\n")
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 1
+
+    def test_fail_multiple_files_all_reported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Multiple failing files: all reported, exit 1."""
+        paths = ["src/a.oct.md", "src/b.oct.md"]
+        for p in paths:
+            _write_oct_md(tmp_path, p, "  TYPE::AGENT_DEFINITION\n")
+        from scripts.ci.validate_canonical_paths import main
+
+        result = main(["--repo-root", str(tmp_path)] + paths)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "src/a.oct.md" in captured.err
+        assert "src/b.oct.md" in captured.err
+
+    def test_fail_partial_batch_exit_1(self, tmp_path: Path) -> None:
+        """One passing + one failing file → exit 1."""
+        good = "src/good.oct.md"
+        bad = "src/bad.oct.md"
+        _write_oct_md(tmp_path, good, f'  SOURCE::"{good}"\n')
+        _write_oct_md(tmp_path, bad, "  TYPE::STANDARD\n")
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), good, bad]) == 1
+
+    # ------------------------------------------------------------------
+    # Internal helper tests
+    # ------------------------------------------------------------------
+
+    def test_extract_meta_fields_quoted(self, tmp_path: Path) -> None:
+        """_extract_meta_fields parses quoted CANONICAL and SOURCE values."""
+        from scripts.ci.validate_canonical_paths import _extract_meta_fields
+
+        content = (
+            "===DOC===\n"
+            "META:\n"
+            '  CANONICAL::".hestai-sys/foo/bar.oct.md"\n'
+            '  SOURCE::"src/foo/bar.oct.md"\n'
+            "§1::SECTION\n===END===\n"
+        )
+        fields = _extract_meta_fields(content)
+        assert fields.get("CANONICAL") == ".hestai-sys/foo/bar.oct.md"
+        assert fields.get("SOURCE") == "src/foo/bar.oct.md"
+
+    def test_extract_meta_fields_unquoted(self, tmp_path: Path) -> None:
+        """_extract_meta_fields parses unquoted CANONICAL values."""
+        from scripts.ci.validate_canonical_paths import _extract_meta_fields
+
+        content = (
+            "===DOC===\n"
+            "META:\n"
+            "  CANONICAL::.hestai/rules/hub-authoring-rules.oct.md\n"
+            "§1::SECTION\n===END===\n"
+        )
+        fields = _extract_meta_fields(content)
+        assert fields.get("CANONICAL") == ".hestai/rules/hub-authoring-rules.oct.md"
+
+    def test_extract_meta_fields_legacy(self, tmp_path: Path) -> None:
+        """_extract_meta_fields parses SOURCE::legacy."""
+        from scripts.ci.validate_canonical_paths import _extract_meta_fields
+
+        content = "===DOC===\nMETA:\n  SOURCE::legacy\n§1::SECTION\n===END===\n"
+        fields = _extract_meta_fields(content)
+        assert fields.get("SOURCE") == "legacy"
+
+    def test_extract_meta_fields_stops_at_section(self, tmp_path: Path) -> None:
+        """_extract_meta_fields does not parse SOURCE in body sections."""
+        from scripts.ci.validate_canonical_paths import _extract_meta_fields
+
+        content = (
+            "===DOC===\n"
+            "META:\n"
+            "  TYPE::STANDARD\n"
+            "§1::SECTION\n"
+            '  SOURCE::"should-not-be-parsed.oct.md"\n'
+            "===END===\n"
+        )
+        fields = _extract_meta_fields(content)
+        assert "SOURCE" not in fields
+
+    def test_normalize_path_strips_dot_slash(self) -> None:
+        """_normalize_path strips leading ./ for comparison."""
+        from scripts.ci.validate_canonical_paths import _normalize_path
+
+        assert _normalize_path("./src/foo/bar.oct.md") == "src/foo/bar.oct.md"
+        assert _normalize_path("src/foo/bar.oct.md") == "src/foo/bar.oct.md"
+        assert _normalize_path(".hestai/rules/foo.oct.md") == ".hestai/rules/foo.oct.md"

--- a/tests/unit/scripts/test_validate_canonical_paths.py
+++ b/tests/unit/scripts/test_validate_canonical_paths.py
@@ -248,3 +248,59 @@ class TestValidateCanonicalPaths:
         assert _normalize_path("./src/foo/bar.oct.md") == "src/foo/bar.oct.md"
         assert _normalize_path("src/foo/bar.oct.md") == "src/foo/bar.oct.md"
         assert _normalize_path(".hestai/rules/foo.oct.md") == ".hestai/rules/foo.oct.md"
+
+    # ------------------------------------------------------------------
+    # CRS rework: edge cases identified in review
+    # ------------------------------------------------------------------
+
+    def test_pass_root_level_file_no_slash(self, tmp_path: Path) -> None:
+        """Root-level .oct.md with SOURCE::"root.oct.md" (no /) must pass.
+
+        The '/' guard in the original implementation incorrectly blocked root
+        files whose SOURCE value contains no path separator.
+        """
+        rel = "root.oct.md"
+        _write_oct_md(tmp_path, rel, f'  SOURCE::"{rel}"\n')
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_pass_meta_with_blank_line_between_fields(self, tmp_path: Path) -> None:
+        """Blank line inside META block must not truncate field extraction.
+
+        The original _RE_META_BLOCK regex required every line to be indented,
+        stopping capture at the first blank line and silently missing subsequent
+        CANONICAL/SOURCE declarations.
+        """
+        rel = "src/foo/spaced.oct.md"
+        (tmp_path / "src" / "foo").mkdir(parents=True, exist_ok=True)
+        (tmp_path / rel).write_text(
+            "===DOC===\n"
+            "META:\n"
+            "  TYPE::STANDARD\n"
+            "\n"
+            f'  SOURCE::"{rel}"\n'
+            "§1::CONTENT\n"
+            "  VALUE::test\n"
+            "===END===\n",
+            encoding="utf-8",
+        )
+        from scripts.ci.validate_canonical_paths import main
+
+        assert main(["--repo-root", str(tmp_path), rel]) == 0
+
+    def test_extract_meta_fields_blank_line_in_meta(self) -> None:
+        """_extract_meta_fields must parse SOURCE even after a blank META line."""
+        from scripts.ci.validate_canonical_paths import _extract_meta_fields
+
+        content = (
+            "===DOC===\n"
+            "META:\n"
+            "  TYPE::STANDARD\n"
+            "\n"
+            '  SOURCE::"src/foo/bar.oct.md"\n'
+            "§1::SECTION\n"
+            "===END===\n"
+        )
+        fields = _extract_meta_fields(content)
+        assert fields.get("SOURCE") == "src/foo/bar.oct.md"


### PR DESCRIPTION
## Summary
- Implement canonical path validation to enforce META.CANONICAL and SOURCE path standards across the codebase
- Add CI/CD integration via pre-commit hooks and GitHub Actions workflow to catch path violations early
- Establish automated validation for documentation structure consistency (issue #394)

## Changes
- **Validation logic**: New `scripts/ci/validate_canonical_paths.py` module with comprehensive path validation rules
- **Testing**: Added 250+ lines of unit tests in `tests/unit/scripts/test_validate_canonical_paths.py` covering edge cases and validation scenarios
- **CI integration**: Updated `.github/workflows/ci.yml` and `.pre-commit-config.yaml` to run canonical path validation on commits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical-path validator for `.oct.md` and integrates it into pre-commit and CI to enforce `META.CANONICAL`/`META.SOURCE`. Fixes parsing for root-level files and blank `META` lines, makes invocations space-safe, and adds a clean error when `git` is missing; addresses #394.

- **New Features**
  - New `scripts/ci/validate_canonical_paths.py` validates `META.CANONICAL`/`META.SOURCE`, normalizes paths (strips leading `./`), supports `legacy` bypass, reports all failures, and supports `--staged`.
  - CI step validates changed `.oct.md`; pre-commit hook validates staged `.oct.md`.
  - Unit tests cover matching, bypass, and error reporting.

- **Bug Fixes**
  - Accepts root-level `.oct.md` where `SOURCE` has no `/`.
  - `META` parsing now tolerates blank lines within the block.
  - Space-safe invocation: pre-commit calls the script with `--staged` (uses `git diff -z`), and CI loops over files; avoids `xargs` and handles spaces in filenames.
  - Git subprocess calls now fail gracefully with a clear message when `git` is missing.

<sup>Written for commit 239fb626cd35640fe688e27a9e718a712ba143f2. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/HestAI-MCP/pull/395?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

