### PR TITLE
fix(review-formats): accept markdown heading format in approvals

### DIFF
--- a/src/hestai_mcp/modules/tools/shared/review_formats.py
+++ b/src/hestai_mcp/modules/tools/shared/review_formats.py
@@ -44,6 +44,8 @@ def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
       - 'CRS  APPROVED' (extra whitespace)
       - 'IL SELF-REVIEWED:' and 'IL (Claude): SELF-REVIEWED:'
       - '| CRS | Gemini | **APPROVED** |' (markdown table with bold)
+      - '## TMG APPROVED ✅' (markdown heading, stripped before matching)
+      - '  ## CRS APPROVED:' (indented markdown heading)
 
     Uses word boundaries around both prefix and keyword to prevent false
     positives (e.g., 'XCRS' must not match 'CRS', 'APPROVEDLY' must not
@@ -111,6 +113,11 @@ def has_crs_model_approval(texts: list[str], model: str) -> bool:
     separator characters (whitespace, colon, dashes) in between. This prevents
     spoofing where a single APPROVED keyword satisfies multiple model checks,
     or where intervening tokens like BLOCKED are ignored.
+
+    Note: this function does NOT strip markdown heading markers. It is
+    intentionally stricter than matches_approval_pattern() — its purpose is
+    spoofing prevention (ensuring a specific model name is present), not
+    format tolerance.
 
     Args:
         texts: List of comment/body texts to search.

--- a/src/hestai_mcp/modules/tools/shared/review_formats.py
+++ b/src/hestai_mcp/modules/tools/shared/review_formats.py
@@ -69,13 +69,17 @@ def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
     # after a markdown table pipe character.
     prefix_re = re.compile(rf"(?:^|(?<=\|))\s*{re.escape(prefix)}\b", re.MULTILINE | re.IGNORECASE)
     keyword_re = re.compile(rf"\b{re.escape(keyword)}\b", re.IGNORECASE)
+    # Strip markdown heading markers (##, ###, etc.) per-line so agents that
+    # write '## TMG APPROVED ✅' are accepted alongside the canonical format.
+    heading_re = re.compile(r"^#{1,6}\s*")
 
     for line in cleaned.splitlines():
-        prefix_match = prefix_re.search(line)
+        stripped = heading_re.sub("", line)
+        prefix_match = prefix_re.search(stripped)
         if not prefix_match:
             continue
         # Keyword must appear after the prefix on the same line
-        keyword_match = keyword_re.search(line, prefix_match.end())
+        keyword_match = keyword_re.search(stripped, prefix_match.end())
         if keyword_match:
             return True
 

--- a/src/hestai_mcp/modules/tools/shared/review_formats.py
+++ b/src/hestai_mcp/modules/tools/shared/review_formats.py
@@ -71,7 +71,7 @@ def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
     keyword_re = re.compile(rf"\b{re.escape(keyword)}\b", re.IGNORECASE)
     # Strip markdown heading markers (##, ###, etc.) per-line so agents that
     # write '## TMG APPROVED ✅' are accepted alongside the canonical format.
-    heading_re = re.compile(r"^#{1,6}\s*")
+    heading_re = re.compile(r"^\s*#{1,6}\s*")
 
     for line in cleaned.splitlines():
         stripped = heading_re.sub("", line)

--- a/tests/unit/mcp/tools/shared/test_review_formats.py
+++ b/tests/unit/mcp/tools/shared/test_review_formats.py
@@ -322,27 +322,32 @@ class TestHelperFunctions:
 class TestHelperFunctionsHeadingFormat:
     """Test that helper functions accept heading-format approvals via matches_approval_pattern."""
 
-    def test_has_crs_approval_with_h2_heading(self):
+    def test_has_crs_approval_with_h2_heading(self) -> None:
+        """has_crs_approval returns True for an H2 CRS approval heading."""
         from hestai_mcp.modules.tools.shared.review_formats import has_crs_approval
 
         assert has_crs_approval(["## CRS APPROVED: looks good"])
 
-    def test_has_ce_approval_with_h2_heading(self):
+    def test_has_ce_approval_with_h2_heading(self) -> None:
+        """has_ce_approval returns True for an H2 CE approval heading."""
         from hestai_mcp.modules.tools.shared.review_formats import has_ce_approval
 
         assert has_ce_approval(["## CE APPROVED: architecture sound"])
 
-    def test_has_tmg_approval_with_h2_heading(self):
+    def test_has_tmg_approval_with_h2_heading(self) -> None:
+        """has_tmg_approval returns True for an H2 TMG approval heading."""
         from hestai_mcp.modules.tools.shared.review_formats import has_tmg_approval
 
         assert has_tmg_approval(["## TMG APPROVED ✅"])
 
-    def test_has_civ_approval_with_h2_heading(self):
+    def test_has_civ_approval_with_h2_heading(self) -> None:
+        """has_civ_approval returns True for an H2 CIV approval heading."""
         from hestai_mcp.modules.tools.shared.review_formats import has_civ_approval
 
         assert has_civ_approval(["## CIV APPROVED: implementation valid"])
 
-    def test_has_crs_approval_with_indented_heading(self):
+    def test_has_crs_approval_with_indented_heading(self) -> None:
+        """has_crs_approval returns True for an indented H2 CRS approval heading."""
         from hestai_mcp.modules.tools.shared.review_formats import has_crs_approval
 
         assert has_crs_approval(["  ## CRS APPROVED: indented"])

--- a/tests/unit/mcp/tools/shared/test_review_formats.py
+++ b/tests/unit/mcp/tools/shared/test_review_formats.py
@@ -215,6 +215,47 @@ class TestMatchesApprovalPattern:
 
         assert not matches_approval_pattern("", "CRS", "APPROVED")
 
+    def test_markdown_h2_heading_format(self) -> None:
+        """Matches '## TMG APPROVED ✅' — agents naturally use heading format."""
+        from hestai_mcp.modules.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("## TMG APPROVED ✅", "TMG", "APPROVED")
+
+    def test_markdown_h1_heading_format(self) -> None:
+        """Matches '# CRS APPROVED: assessment' with h1 heading marker."""
+        from hestai_mcp.modules.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("# CRS APPROVED: assessment", "CRS", "APPROVED")
+
+    def test_markdown_h3_heading_format(self) -> None:
+        """Matches '### CIV APPROVED: assessment' with deep heading marker."""
+        from hestai_mcp.modules.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("### CIV APPROVED: assessment", "CIV", "APPROVED")
+
+    def test_markdown_heading_with_go_keyword(self) -> None:
+        """Matches '## TMG GO ✅' — heading format with GO keyword."""
+        from hestai_mcp.modules.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("## TMG GO ✅", "TMG", "GO")
+
+    def test_markdown_heading_in_multiline(self) -> None:
+        """Matches heading-format approval within multiline review comment."""
+        from hestai_mcp.modules.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        text = "Review summary:\n\n## TMG APPROVED ✅\n\nAll checks passed."
+        assert matches_approval_pattern(text, "TMG", "APPROVED")
+
 
 @pytest.mark.unit
 class TestHelperFunctions:

--- a/tests/unit/mcp/tools/shared/test_review_formats.py
+++ b/tests/unit/mcp/tools/shared/test_review_formats.py
@@ -256,6 +256,14 @@ class TestMatchesApprovalPattern:
         text = "Review summary:\n\n## TMG APPROVED ✅\n\nAll checks passed."
         assert matches_approval_pattern(text, "TMG", "APPROVED")
 
+    def test_indented_markdown_heading_format(self) -> None:
+        """Matches '  ## TMG APPROVED ✅' — heading with leading indentation."""
+        from hestai_mcp.modules.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("  ## TMG APPROVED ✅", "TMG", "APPROVED")
+
 
 @pytest.mark.unit
 class TestHelperFunctions:

--- a/tests/unit/mcp/tools/shared/test_review_formats.py
+++ b/tests/unit/mcp/tools/shared/test_review_formats.py
@@ -319,6 +319,36 @@ class TestHelperFunctions:
 
 
 @pytest.mark.unit
+class TestHelperFunctionsHeadingFormat:
+    """Test that helper functions accept heading-format approvals via matches_approval_pattern."""
+
+    def test_has_crs_approval_with_h2_heading(self):
+        from hestai_mcp.modules.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval(["## CRS APPROVED: looks good"])
+
+    def test_has_ce_approval_with_h2_heading(self):
+        from hestai_mcp.modules.tools.shared.review_formats import has_ce_approval
+
+        assert has_ce_approval(["## CE APPROVED: architecture sound"])
+
+    def test_has_tmg_approval_with_h2_heading(self):
+        from hestai_mcp.modules.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval(["## TMG APPROVED ✅"])
+
+    def test_has_civ_approval_with_h2_heading(self):
+        from hestai_mcp.modules.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval(["## CIV APPROVED: implementation valid"])
+
+    def test_has_crs_approval_with_indented_heading(self):
+        from hestai_mcp.modules.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval(["  ## CRS APPROVED: indented"])
+
+
+@pytest.mark.unit
 class TestFormatReviewComment:
     """Test comment formatting that produces gate-clearable comments."""
 


### PR DESCRIPTION
## Summary
- Gate parser now accepts both colon-delimited and markdown heading formats for approval comments
- Resolves issue where TMG and CIV agents use ## ROLE APPROVED ✅ format instead of ROLE APPROVED: format
- Eliminates need to retrain agents on specific comment formatting

## Changes
- **review_formats.py**: Updated approval pattern matching to recognize markdown heading syntax (##) in addition to existing colon-based format
- **test_review_formats.py**: Added 41 lines of test coverage validating both approval comment formats are correctly parsed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept markdown heading approvals like "## TMG APPROVED ✅" (including indented headings) alongside the colon format. Fixes missed approvals from TMG and CIV without retraining agents.

- **Bug Fixes**
  - Strip leading whitespace and markdown heading markers (#{1–6}) per line before matching the prefix and keyword.
  - Add tests for H1–H3, APPROVED/GO, multiline, indented headings, and helper functions (`has_*_approval`); update docstrings to note heading support and that `has_crs_model_approval` remains strict for spoofing prevention.

- **Refactors**
  - Add docstrings and -> None return annotations to the new heading-format tests for consistency.

<sup>Written for commit 047aa48a2422e5eb9380b967325865f4a697dc89. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/HestAI-MCP/pull/396?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

