### PR TITLE
fix(review-gate): include PR review bodies in approval matching

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -14,6 +14,8 @@ name: Review Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
   issue_comment:
     types: [created, edited]
   workflow_call:
@@ -36,6 +38,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request'
       || github.event_name == 'workflow_call'
+      || github.event_name == 'pull_request_review'
       || (github.event.issue.pull_request
           && github.event.comment.user.type != 'Bot'
           && (contains(github.event.comment.body, 'APPROVED')
@@ -98,6 +101,8 @@ jobs:
             echo "number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
             # For issue_comment events on PRs
             PR_NUMBER=$(echo "${{ github.event.issue.pull_request.url }}" | grep -oE '[0-9]+$')
@@ -109,9 +114,9 @@ jobs:
       # Parse the existing status comment for cached tier/reviewers/SHA to avoid
       # re-running file classification. If the cached SHA matches the PR head,
       # pass the cached data to validate_review.py via CACHED_GATE_DATA.
-      - name: Extract cached gate data (comment events only)
+      - name: Extract cached gate data (comment and review events)
         id: cached_gate
-        if: github.event_name == 'issue_comment'
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -397,6 +402,9 @@ jobs:
           # Get the PR's head SHA
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            # pull_request_review exposes the reviewed commit directly
+            PR_HEAD_SHA="${{ github.event.review.commit_id }}"
           else
             # For issue_comment events, fetch from API
             PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -403,8 +403,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            # pull_request_review exposes the reviewed commit directly
-            PR_HEAD_SHA="${{ github.event.review.commit_id }}"
+            PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           else
             # For issue_comment events, fetch from API
             PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -483,22 +483,22 @@ def check_pr_comments(
 
     print(f"   Checking PR #{pr_number} for review comments...")
 
-    # Use gh CLI to get comments and PR body
+    # Use gh CLI to get comments, PR body, and PR reviews
     try:
         result = subprocess.run(
-            ["gh", "pr", "view", pr_number, "--json", "comments,body"],
+            ["gh", "pr", "view", pr_number, "--json", "comments,body,reviews"],
             capture_output=True,
             text=True,
             check=True,
         )
         pr_data = json.loads(result.stdout)
 
-        # Collect all searchable text: PR body + comment bodies
-        # Exclude ALL bot comments to prevent false positive approval matches.
+        # Collect all searchable text: PR body + comment bodies + review bodies
+        # Exclude ALL bot comments/reviews to prevent false positive approval matches.
         # Bot review prose (Copilot, Cubic, github-actions) often
         # contains "APPROVED", "GO", etc. which would falsely clear the gate.
         def _is_bot_comment(comment: dict[str, Any]) -> bool:
-            """Check if a comment is from a bot author."""
+            """Check if a comment or review is from a bot author."""
             login = comment.get("author", {}).get("login", "")
             if login in _BOT_LOGIN_SET:
                 return True
@@ -521,6 +521,19 @@ def check_pr_comments(
                 skipped_bots.append(bot_login)
             else:
                 searchable_texts.append(c.get("body", ""))
+
+        # Include PR review bodies — GitHub PR Reviews (submitted via the Review
+        # button, pulls/{n}/reviews API) are a separate resource from issue-level
+        # comments.  Reviewers who self-review must use state=COMMENTED (GitHub
+        # forbids self-approve), so we check body text only — not state.
+        for r in pr_data.get("reviews", []):
+            if _is_bot_comment(r):
+                bot_login = r.get("author", {}).get("login", "unknown")
+                skipped_bots.append(bot_login)
+            else:
+                review_body = r.get("body", "")
+                if review_body:
+                    searchable_texts.append(review_body)
 
         if skipped_bots:
             print(

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -525,8 +525,13 @@ def check_pr_comments(
         # Include PR review bodies — GitHub PR Reviews (submitted via the Review
         # button, pulls/{n}/reviews API) are a separate resource from issue-level
         # comments.  Reviewers who self-review must use state=COMMENTED (GitHub
-        # forbids self-approve), so we check body text only — not state.
+        # forbids self-approve).  DISMISSED reviews are excluded: the reviewer
+        # retracted their assessment, so it must not satisfy the gate.
+        # PENDING reviews have not been submitted yet and are also excluded.
+        active_review_states: frozenset[str] = frozenset({"APPROVED", "COMMENTED"})
         for r in pr_data.get("reviews", []):
+            if r.get("state") not in active_review_states:
+                continue
             if _is_bot_comment(r):
                 bot_login = r.get("author", {}).get("login", "unknown")
                 skipped_bots.append(bot_login)

--- a/tests/test_validate_review.py
+++ b/tests/test_validate_review.py
@@ -516,7 +516,7 @@ class TestPRBodyScanning:
         assert approved is True, "Approvals split between body and comments should pass"
 
     def test_gh_cli_fetches_body_and_comments(self, ci_environment, monkeypatch):
-        """The gh CLI call should request both 'body' and 'comments' fields."""
+        """The gh CLI call should request 'body', 'comments', and 'reviews' fields."""
         captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
@@ -529,6 +529,7 @@ class TestPRBodyScanning:
                             {"body": "CRS APPROVED: ok"},
                             {"body": "CE APPROVED: ok"},
                         ],
+                        "reviews": [],
                     }
                 ),
                 returncode=0,
@@ -539,12 +540,12 @@ class TestPRBodyScanning:
 
         validate_review.check_pr_comments("TIER_2_STANDARD")
 
-        # Verify gh pr view fetches both body and comments
+        # Verify gh pr view fetches body, comments, and reviews
         assert len(captured_cmds) > 0
         gh_cmd = captured_cmds[0]
-        assert (
-            "comments,body" in gh_cmd or "body,comments" in gh_cmd
-        ), f"gh CLI should fetch both comments and body, got: {gh_cmd}"
+        json_arg = next((a for a in gh_cmd if "comments" in a and "body" in a), None)
+        assert json_arg is not None, f"gh CLI should fetch comments and body, got: {gh_cmd}"
+        assert "reviews" in json_arg, f"gh CLI should also fetch reviews, got: {gh_cmd}"
 
     def test_empty_pr_body_still_checks_comments(self, ci_environment, monkeypatch):
         """Empty or null PR body should not break comment checking."""

--- a/tests/unit/scripts/test_validate_review_pr_reviews.py
+++ b/tests/unit/scripts/test_validate_review_pr_reviews.py
@@ -1,10 +1,9 @@
 """Tests for check_pr_comments() including PR review bodies.
 
-TDD RED phase: written before the fix is implemented.
-
 Contract:
 - check_pr_comments() fetches `reviews` alongside `comments,body`
-- Each review's .body is included in searchable_texts (same as a comment)
+- Each review's .body is included in searchable_texts for APPROVED and COMMENTED states
+- DISMISSED and PENDING reviews are excluded regardless of body content
 - Bot reviews are excluded using the same _BOT_LOGIN_SET logic
 - A review body containing a valid approval satisfies the relevant role checker
 - Existing comment-path behaviour is unaffected (no regression)
@@ -189,6 +188,97 @@ class TestCheckPrCommentsIncludesReviews:
         approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
         assert approved is False
         assert "CE" in missing
+
+
+# ---------------------------------------------------------------------------
+# Tests: dismissed and pending reviews are excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsReviewStateFiltering:
+    """Only APPROVED and COMMENTED reviews must contribute to approval matching."""
+
+    def test_dismissed_review_approval_is_ignored(self) -> None:
+        """A DISMISSED review containing an approval keyword must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "DISMISSED",
+                    "body": "CRS APPROVED: looked good at the time",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "DISMISSED review must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_pending_review_approval_is_ignored(self) -> None:
+        """A PENDING review (not yet submitted) must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "ce-agent"},
+                    "state": "PENDING",
+                    "body": "CE APPROVED: draft review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is False, "PENDING review must not satisfy the gate"
+        assert "CE" in missing
+
+    def test_commented_review_approval_is_included(self) -> None:
+        """A COMMENTED review (self-review state) must satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: review complete",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "COMMENTED review must satisfy the gate"
+        assert missing == []
+
+    def test_approved_state_review_is_included(self) -> None:
+        """A review with state=APPROVED must also satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "APPROVED",
+                    "body": "CRS APPROVED: full approval",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "APPROVED-state review must satisfy the gate"
+        assert missing == []
+
+    def test_dismissed_review_does_not_block_valid_comment_approval(self) -> None:
+        """A dismissed review for a role must not prevent a valid comment from satisfying it."""
+        pr_data = _make_pr_data(
+            comments=[
+                {
+                    "author": {"login": "crs-user"},
+                    "body": "CRS APPROVED: approved via comment",
+                }
+            ],
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "DISMISSED",
+                    "body": "CRS APPROVED: earlier dismissed review",
+                }
+            ],
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "Valid comment approval must satisfy gate despite dismissed review"
+        assert missing == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_validate_review_pr_reviews.py
+++ b/tests/unit/scripts/test_validate_review_pr_reviews.py
@@ -1,0 +1,316 @@
+"""Tests for check_pr_comments() including PR review bodies.
+
+TDD RED phase: written before the fix is implemented.
+
+Contract:
+- check_pr_comments() fetches `reviews` alongside `comments,body`
+- Each review's .body is included in searchable_texts (same as a comment)
+- Bot reviews are excluded using the same _BOT_LOGIN_SET logic
+- A review body containing a valid approval satisfies the relevant role checker
+- Existing comment-path behaviour is unaffected (no regression)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pr_data(
+    *,
+    body: str = "",
+    comments: list[dict[str, Any]] | None = None,
+    reviews: list[dict[str, Any]] | None = None,
+) -> str:
+    """Build the JSON string that `gh pr view` would emit."""
+    return json.dumps(
+        {
+            "body": body,
+            "comments": comments or [],
+            "reviews": reviews or [],
+        }
+    )
+
+
+def _run_check(
+    pr_data_json: str,
+    required_roles: set[str] | None = None,
+    tier: str = "",
+) -> tuple[bool, str, list[str]]:
+    """Invoke check_pr_comments with a mocked subprocess and CI env."""
+    mock_result = MagicMock()
+    mock_result.stdout = pr_data_json
+
+    env_patch = {"CI": "true", "PR_NUMBER": "42"}
+
+    with (
+        patch.dict(os.environ, env_patch),
+        patch("scripts.validate_review.subprocess.run", return_value=mock_result),
+    ):
+        from scripts.validate_review import check_pr_comments
+
+        return check_pr_comments(required_roles=required_roles, tier=tier)
+
+
+# ---------------------------------------------------------------------------
+# Tests: review bodies ARE included in searchable_texts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsIncludesReviews:
+    """check_pr_comments() must include PR review bodies in approval search."""
+
+    def test_crs_approval_in_review_body_satisfies_gate(self) -> None:
+        """A CRS APPROVED verdict posted as a PR review body must pass the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: looks good",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, f"Expected approval from review body; missing={missing}"
+        assert missing == []
+
+    def test_ce_approval_in_review_body_satisfies_gate(self) -> None:
+        """A CE APPROVED verdict in a PR review body must pass the CE check."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "ce-agent"},
+                    "state": "COMMENTED",
+                    "body": "CE APPROVED: implementation is clean",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is True, f"Expected approval from review body; missing={missing}"
+        assert missing == []
+
+    def test_tmg_approval_in_review_body_satisfies_gate(self) -> None:
+        """A TMG APPROVED verdict in a PR review body must pass the TMG check."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "tmg-agent"},
+                    "state": "COMMENTED",
+                    "body": "## TMG APPROVED ✅\nAll checks pass.",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"TMG"})
+        assert approved is True, f"Expected approval from review body; missing={missing}"
+        assert missing == []
+
+    def test_multiple_roles_all_in_review_bodies(self) -> None:
+        """Multiple roles approved via PR review bodies all satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "tmg-agent"},
+                    "state": "COMMENTED",
+                    "body": "TMG APPROVED: structural review complete",
+                },
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: code quality confirmed",
+                },
+                {
+                    "author": {"login": "ce-agent"},
+                    "state": "COMMENTED",
+                    "body": "CE APPROVED: engineering standards met",
+                },
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"TMG", "CRS", "CE"})
+        assert approved is True, f"Expected all roles approved; missing={missing}"
+        assert missing == []
+
+    def test_approvals_split_across_comments_and_reviews(self) -> None:
+        """One role approved via issue comment, another via PR review body."""
+        pr_data = _make_pr_data(
+            comments=[
+                {
+                    "author": {"login": "ce-user"},
+                    "body": "CE APPROVED: implementation looks correct",
+                }
+            ],
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: passes review",
+                }
+            ],
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE", "CRS"})
+        assert approved is True, f"Expected both roles satisfied; missing={missing}"
+        assert missing == []
+
+    def test_review_body_without_approval_does_not_satisfy(self) -> None:
+        """A review body without an approval pattern must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "reviewer"},
+                    "state": "COMMENTED",
+                    "body": "Looking at this PR now, will review shortly.",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False
+        assert "CRS" in missing
+
+    def test_missing_role_still_reported_when_review_has_different_role(self) -> None:
+        """A review body satisfying CRS must not satisfy CE."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: code quality confirmed",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is False
+        assert "CE" in missing
+
+
+# ---------------------------------------------------------------------------
+# Tests: bot reviews are excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsBotReviewExclusion:
+    """Bot-authored PR review bodies must be excluded from approval matching."""
+
+    def test_bot_review_approval_is_ignored(self) -> None:
+        """A CRS APPROVED in a review from a known bot must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "github-actions"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: auto-generated review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "Bot review approval must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_copilot_review_approval_is_ignored(self) -> None:
+        """A CE APPROVED in a review from github-copilot bot must be excluded."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "Copilot"},
+                    "state": "COMMENTED",
+                    "body": "CE APPROVED: copilot auto-review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is False, "Copilot bot review must not satisfy the gate"
+        assert "CE" in missing
+
+    def test_bot_suffix_review_approval_is_ignored(self) -> None:
+        """A review from any [bot]-suffixed account must be excluded."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "some-new-bot[bot]"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: auto-review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "[bot]-suffixed review must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_human_review_with_bot_marker_is_excluded(self) -> None:
+        """A review body containing the review-gate-status marker must be excluded."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "some-human"},
+                    "state": "COMMENTED",
+                    "body": "<!-- review-gate-status -->\nCRS APPROVED: injected",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "Status-marker review must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_human_non_bot_review_is_included(self) -> None:
+        """A review from a non-bot human account must be included."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "shaun"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: reviewed by human",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "Human review must satisfy the gate"
+        assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: no regression on existing comment path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsNoRegression:
+    """Existing comment-based approval path must still work after the fix."""
+
+    def test_comment_approval_still_works(self) -> None:
+        """CRS approval in an issue comment still satisfies the gate (no regression)."""
+        pr_data = _make_pr_data(
+            comments=[
+                {
+                    "author": {"login": "crs-user"},
+                    "body": "CRS APPROVED: all good",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True
+        assert missing == []
+
+    def test_pr_body_approval_still_works(self) -> None:
+        """CRS approval in the PR body itself still satisfies the gate."""
+        pr_data = _make_pr_data(body="CRS APPROVED: in the PR description")
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True
+        assert missing == []
+
+    def test_empty_reviews_field_does_not_crash(self) -> None:
+        """When reviews key is absent from API response, the gate must not crash."""
+        # Simulate old response format without reviews key
+        pr_data_dict = {"body": "", "comments": []}
+        pr_data = json.dumps(pr_data_dict)
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False  # No approval present
+        assert "CRS" in missing


### PR DESCRIPTION
## Summary
- Extended review-gate workflow to parse approval comments from PR review bodies, not just commit comments
- Added trigger on `pull_request_review` event to catch review approvals in real-time
- Fixes issue where valid reviews were not being counted toward required approval threshold

## Changes
- **scripts/validate_review.py**: Updated approval matching logic to search PR review bodies for approval markers (e.g., `##`)
- **.github/workflows/review-gate.yml**: Added `pull_request_review` event trigger and configured to pass review event data to validation script
- **tests/test_validate_review.py**: Updated existing tests for new body-parsing behavior
- **tests/scripts/test_validate_review_pr_reviews.py**: Added comprehensive test suite (316 lines) covering PR review body parsing scenarios

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missed approvals by parsing PR review bodies and running on `pull_request_review` events so human approvals count in real time. Skips bot, dismissed, and pending reviews, and uses the PR head SHA for accurate status updates.

- **Bug Fixes**
  - Updated `scripts/validate_review.py` to fetch `comments,body,reviews`, include bodies from APPROVED/COMMENTED reviews, and ignore DISMISSED/PENDING and bot-authored content.
  - Extended `.github/workflows/review-gate.yml` to trigger on `pull_request_review`, pass the PR number, reuse cached gate data, and use `github.event.pull_request.head.sha` for the head SHA.
  - Updated tests to expect `reviews` and added a suite covering review-body parsing, state filtering, bot exclusion, and no regressions on comments/PR body.

<sup>Written for commit 9aa61213df0e02895422ba5cac82a504d0639041. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/HestAI-MCP/pull/397?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

