### PR TITLE
test(governance): self-application guard for W_SNAKE_CASE_BLOB (#406 follow-up)

### DIFF
--- a/tests/unit/governance/test_skills_self_apply.py
+++ b/tests/unit/governance/test_skills_self_apply.py
@@ -1,0 +1,81 @@
+"""Self-application guard — bundled-hub + project NS artifacts must satisfy octave-mcp validators.
+
+Walks every ``*.md`` and ``*.oct.md`` under ``src/hestai_mcp/_bundled_hub/`` and the
+project-local ``.hestai/north-star/`` tree and runs octave-mcp's ``W_SNAKE_CASE_BLOB``
+detector on each. Asserts zero hits.
+
+WHY THIS EXISTS (#406 Phase 1/2)
+--------------------------------
+``W_SNAKE_CASE_BLOB`` flags snake-fragmented prose in reasoning-field positions
+(DECISION, BECAUSE, RATIONALE, PRINCIPLE, WHY, ...). The bundled hub injects into
+``.hestai-sys/`` at MCP server startup, so a blob shipped here teaches every
+downstream agent that blobs are canonical — an autocatalytic corruption loop
+(see octave-mcp#452). PRs #408/#409/#410 cleared the existing hits and migrated
+the North Star summaries to TELEGRAPHIC_PHRASE / UPOG form; this test is the
+mechanical guard that keeps the surface clean going forward.
+
+If this test fails after an upstream octave-mcp release, the validator likely got
+stricter — investigate whether the new triggers are correct, then either fix the
+surfaced artifacts (telegraphic-phrase per octave-compression §4 R3a) or escalate
+to the octave-mcp maintainers. Do not silence the guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("octave_mcp", reason="octave-mcp not installed")
+
+# Private API tracked deliberately — octave-mcp does not yet export a public entry
+# point for the W_SNAKE_CASE_BLOB detector. Revisit if upstream renames or promotes
+# the function (grep "W_SNAKE_CASE_BLOB" in the installed octave_mcp package).
+from octave_mcp.mcp.write_detection import _detect_snake_case_blob  # noqa: PLC2701
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCAN_ROOTS = [
+    _REPO_ROOT / "src" / "hestai_mcp" / "_bundled_hub",
+    _REPO_ROOT / ".hestai" / "north-star",
+]
+
+
+def _scan_targets() -> list[Path]:
+    files: set[Path] = set()
+    for root in _SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for pattern in ("*.md", "*.oct.md"):
+            files.update(root.rglob(pattern))
+    return sorted(files)
+
+
+@pytest.mark.smoke
+@pytest.mark.unit
+class TestBundledHubSelfApplication:
+    """Governance artifacts we ship must pass octave-mcp's W_SNAKE_CASE_BLOB detector."""
+
+    def test_scan_targets_are_discovered(self) -> None:
+        """Guard against a silently-empty scan (moved dirs, bad glob) giving false safety."""
+        targets = _scan_targets()
+        assert targets, (
+            "Self-application scan found no .md/.oct.md files under "
+            f"{[str(r) for r in _SCAN_ROOTS]} — the guard would pass vacuously. "
+            "Verify the scan roots still exist."
+        )
+
+    def test_no_w_snake_case_blob_in_shipped_artifacts(self) -> None:
+        """Every scanned artifact emits zero W_SNAKE_CASE_BLOB warnings."""
+        offenders: dict[str, list[dict[str, object]]] = {}
+        for path in _scan_targets():
+            content = path.read_text(encoding="utf-8")
+            warnings = _detect_snake_case_blob(content)
+            if warnings:
+                offenders[str(path.relative_to(_REPO_ROOT))] = warnings
+
+        assert not offenders, (
+            "Snake-case prose blob detected in reasoning-field positions. Convert each "
+            "offender to a TELEGRAPHIC_PHRASE (quoted value, stopwords dropped, operators "
+            "⊕ ⇌ ∧ ∨ → carry English connectives — see octave-compression §4 R3a). "
+            f"Offenders: {offenders}"
+        )


### PR DESCRIPTION
## Summary

Adds the deferred **self-application guard** from #406 Phase 1/2. Walks every
`*.md` / `*.oct.md` under `src/hestai_mcp/_bundled_hub/` and `.hestai/north-star/`
and asserts octave-mcp's `W_SNAKE_CASE_BLOB` detector finds **zero hits**.

PRs #408 / #409 / #410 cleared the existing snake-case-blob hits and migrated the
North Star summaries to TELEGRAPHIC_PHRASE / UPOG form. This test is the mechanical
guard that keeps the surface clean going forward — the bundled hub injects into
`.hestai-sys/` at MCP server startup and acts as few-shot corpus for every agent,
so a single blob shipped here is autocatalytic (the failure mode octave-mcp#452
exists to break).

## What it does

- `test_no_w_snake_case_blob_in_shipped_artifacts` — the core assertion (currently 0 hits across all scanned artifacts).
- `test_scan_targets_are_discovered` — guards against a moved directory or broken glob making the check pass vacuously (no silent false-safety).
- Tracks the private `octave_mcp.mcp.write_detection._detect_snake_case_blob` entry point with a documented note to revisit if upstream promotes/renames it.

## Test plan

- [x] `.venv/bin/python -m ruff check tests` — clean
- [x] `.venv/bin/python -m black --check tests` — clean
- [x] `.venv/bin/python -m mypy src` — 0 errors (47 files)
- [x] `.venv/bin/python -m pytest` — 1094 passed @ 92%
- [ ] CI green on this PR

## Scope

Pure test addition; no source/behaviour change. Marked `smoke` + `unit`.

Refs #406. Remaining tail: `.hestai/rules/ci-progressive-testing.oct.md` UPOG rewrite (last legacy hybrid doc, allowlisted) and the upstream octave-mcp CLI `--schema`/binary-name notes — both tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-application test that scans shipped Markdown artifacts and fails if `octave_mcp`’s `W_SNAKE_CASE_BLOB` finds any hits. This locks in the cleaned state and prevents snake-case prose from slipping into the bundled hub.

- **New Tests**
  - Scans `src/hestai_mcp/_bundled_hub/` and `.hestai/north-star/` for `*.md` and `*.oct.md`.
  - Asserts zero `W_SNAKE_CASE_BLOB` warnings; fails on any offender.
  - Guards against empty scans to avoid false passes.
  - Tracks private `octave_mcp.mcp.write_detection._detect_snake_case_blob` until upstream exports a public entry.

<sup>Written for commit 5b3e4f477d5ccc60cfaadbc657ba5894713965e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/HestAI-MCP/pull/415?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

