### PR TITLE
test(governance): extend self-application W_SNAKE_CASE_BLOB scan to .hestai/rules/

### DIFF
--- a/tests/unit/governance/test_skills_self_apply.py
+++ b/tests/unit/governance/test_skills_self_apply.py
@@ -1,8 +1,8 @@
 """Self-application guard — bundled-hub + project NS artifacts must satisfy octave-mcp validators.
 
 Walks every ``*.md`` and ``*.oct.md`` under ``src/hestai_mcp/_bundled_hub/`` and the
-project-local ``.hestai/north-star/`` tree and runs octave-mcp's ``W_SNAKE_CASE_BLOB``
-detector on each. Asserts zero hits.
+project-local ``.hestai/north-star/`` and ``.hestai/rules/`` trees and runs octave-mcp's
+``W_SNAKE_CASE_BLOB`` detector on each. Asserts zero hits.
 
 WHY THIS EXISTS (#406 Phase 1/2)
 --------------------------------
@@ -37,6 +37,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SCAN_ROOTS = [
     _REPO_ROOT / "src" / "hestai_mcp" / "_bundled_hub",
     _REPO_ROOT / ".hestai" / "north-star",
+    _REPO_ROOT / ".hestai" / "rules",
 ]
 
 

--- a/tests/unit/governance/test_skills_self_apply.py
+++ b/tests/unit/governance/test_skills_self_apply.py
@@ -1,4 +1,4 @@
-"""Self-application guard — bundled-hub + project NS artifacts must satisfy octave-mcp validators.
+"""Self-application guard — bundled-hub + project governance artifacts must satisfy octave-mcp validators.
 
 Walks every ``*.md`` and ``*.oct.md`` under ``src/hestai_mcp/_bundled_hub/`` and the
 project-local ``.hestai/north-star/`` and ``.hestai/rules/`` trees and runs octave-mcp's


### PR DESCRIPTION
## Summary

Closes the non-blocking coverage gap TMG flagged during PR #418 review.

The self-application guard added in #415 (`tests/unit/governance/test_skills_self_apply.py`)
scanned `src/hestai_mcp/_bundled_hub/` + `.hestai/north-star/` for octave-mcp's
`W_SNAKE_CASE_BLOB` detector, but **not** `.hestai/rules/`. The CI/pre-commit
`octave validate` gate covers `.hestai/rules/` for well-formedness, but does NOT
invoke the `W_SNAKE_CASE_BLOB` detector — so snake-fragmented prose in a
reasoning-field there would go uncaught.

This adds `.hestai/rules/` to `_SCAN_ROOTS`.

## Verification

- All 3 current `.hestai/rules/` files (`ci-progressive-testing.oct.md`,
  `hub-authoring-rules.oct.md`, `octave-integration-guide.oct.md`) are already
  blob-clean, so the guard passes immediately — confirmed against `origin/main`
  (i.e. independent of PR #418's merge state).
- Scan now covers 161 targets (3 from `.hestai/rules/`); the non-empty-scan guard
  still holds.
- `ruff` / `black` / `mypy` clean; `pytest` 1094 passed @ 92%.

## Scope

Single-file test change (+3/−2): one `_SCAN_ROOTS` entry + docstring line. No source/behaviour change.

Refs #406 (final hardening of the #415 self-application guard, per PR #418 TMG review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the self-application guard to scan `.hestai/rules/` with `octave-mcp`’s `W_SNAKE_CASE_BLOB`, closing a coverage gap. Adds `.hestai/rules/` to `_SCAN_ROOTS` and updates the docstring to cover all governance artifacts; all current rule files are clean and no source behavior changes.

<sup>Written for commit 68987c26a30003cfa52afd2d191babee1ec8cd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/HestAI-MCP/pull/420?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

