### PR TITLE
fix(review-gate): rename-aware BASE declaration read + numstat path-key bug

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -296,12 +296,6 @@ jobs:
             // visible audit trail of an attempted downgrade that set-union refused.
             // Returns '' when no escalation provenance is present (pure diff-shape).
             function renderProvenance(roleList, prov) {
-              const sourceLabel = {
-                DIFF: 'diff shape',
-                HEAD: 'declared in head blob',
-                BASE: 'declared in base blob',
-                PR_BODY: 'declared in PR body',
-              };
               // Only render when at least one role was escalated by a declaration
               // (i.e. a non-DIFF source contributed). Pure diff-shape PRs stay quiet.
               const escalated = roleList.some(r => {
@@ -309,16 +303,15 @@ jobs:
                 return Array.isArray(s) && s.some(x => x !== 'DIFF');
               });
               if (!escalated) return '';
-              let table = '**Required reviewers** (provenance — escalation-only, set-union cannot subtract):\n';
+              // Sources: DIFF=facets, HEAD/BASE=blob declaration, PR_BODY=declared in PR body.
+              // BASE-only = role was present in base but removed in head (ratchet retained it).
+              let table = '**Required reviewers** (sources: DIFF=facets, HEAD/BASE=blob, PR\\_BODY=PR body):\n';
               table += '```\n';
               for (const role of roleList) {
                 const srcs = Array.isArray(prov[role]) ? prov[role] : [];
-                const labels = srcs.length
-                  ? srcs.map(s => sourceLabel[s] || s).join(', ')
-                  : 'diff shape';
                 // Pad role to 5 chars for column alignment (e.g. "TMG  — ...").
                 const padded = (role + '     ').slice(0, 5);
-                table += `${padded}— ${labels} (${srcs.join(', ') || 'DIFF'})\n`;
+                table += `${padded}— ${srcs.join(', ') || 'DIFF'}\n`;
               }
               table += '```\n';
               return table;

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -126,6 +126,23 @@ def get_changed_files() -> list[dict[str, Any]]:
                 )
             elif len(parts) == 3:
                 added, deleted, filename = parts
+                # Resolve arrow/brace rename notation that real git --numstat emits.
+                # Three forms exist (all 3-field, ' => ' inside the filename field):
+                #   Plain:     "old/path.md => new/path.md"
+                #   Same-dir:  "dir/{old.md => new.md}"
+                #   Cross-dir: "{old/dir => new/dir}/file.md"
+                if " => " in filename:
+                    brace_match = re.search(r"\{([^}]*) => ([^}]*)\}", filename)
+                    if brace_match:
+                        # Replace the entire {old => new} fragment with just the new side.
+                        filename = (
+                            filename[: brace_match.start()]
+                            + brace_match.group(2)
+                            + filename[brace_match.end() :]
+                        )
+                    else:
+                        # Plain "old_path => new_path" — take the new (right) side.
+                        filename = filename.split(" => ", 1)[1]
                 files.append(
                     {
                         "path": filename,

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -52,11 +52,15 @@ def get_changed_files() -> list[dict[str, Any]]:
     """Get list of changed files with line counts and file status.
 
     Each returned dict includes:
-      - path: file path
+      - path: new file path (or current path for non-renamed files)
       - added: lines added
       - deleted: lines deleted
       - total_changed: added + deleted
       - status: git status letter (A=added, M=modified, D=deleted, R=renamed)
+      - previous_path: (renames only) the old file path before the rename
+
+    For renamed files, ``previous_path`` is populated so that callers can
+    fetch the BASE blob using the old path (issue #417).
     """
     try:
         # In CI, compare against base branch; locally use cached
@@ -70,7 +74,37 @@ def get_changed_files() -> list[dict[str, Any]]:
             numstat_cmd = ["git", "diff", "--cached", "--numstat"]
             status_cmd = ["git", "diff", "--cached", "--name-status"]
 
-        # Get diff stats (line counts)
+        # Build rename map from --name-status first: old_path -> new_path.
+        # For renames git emits: "R<score>\t<old_path>\t<new_path>"
+        # We key by new_path to match against numstat entries, and store old_path
+        # as previous_path.
+        status_result = subprocess.run(status_cmd, capture_output=True, text=True, check=True)
+        status_map: dict[str, str] = {}  # new_path -> status letter
+        rename_map: dict[str, str] = {}  # new_path -> old_path
+        for line in status_result.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                # Status is first char of first field (e.g., "M", "A", "R100")
+                status_letter = parts[0][0]
+                if status_letter == "R" and len(parts) >= 3:
+                    # Rename: parts[1]=old_path, parts[2]=new_path
+                    old_path = parts[1]
+                    new_path = parts[2]
+                    status_map[new_path] = "R"
+                    rename_map[new_path] = old_path
+                else:
+                    filename = parts[-1]  # Last field is the path
+                    status_map[filename] = status_letter
+
+        # Get diff stats (line counts).
+        # --numstat for renamed files emits either:
+        #   <added>\t<deleted>\t<old_path>\t<new_path>  (4 fields, with -M)
+        # or the brace-notation form:
+        #   <added>\t<deleted>\t{old => new}  (3 fields)
+        # We normalise both: for the 4-field form use new_path (parts[3]); for
+        # the 3-field form use rename_map to resolve the correct new_path key.
         result = subprocess.run(numstat_cmd, capture_output=True, text=True, check=True)
 
         files = []
@@ -78,7 +112,19 @@ def get_changed_files() -> list[dict[str, Any]]:
             if not line:
                 continue
             parts = line.split("\t")
-            if len(parts) == 3:
+            if len(parts) == 4:
+                # 4-field rename line: added, deleted, old_path, new_path
+                added, deleted, _old, new_path = parts
+                files.append(
+                    {
+                        "path": new_path,
+                        "added": int(added) if added != "-" else 0,
+                        "deleted": int(deleted) if deleted != "-" else 0,
+                        "total_changed": (int(added) if added != "-" else 0)
+                        + (int(deleted) if deleted != "-" else 0),
+                    }
+                )
+            elif len(parts) == 3:
                 added, deleted, filename = parts
                 files.append(
                     {
@@ -90,22 +136,12 @@ def get_changed_files() -> list[dict[str, Any]]:
                     }
                 )
 
-        # Get file statuses (A=added, M=modified, D=deleted, R=renamed)
-        status_result = subprocess.run(status_cmd, capture_output=True, text=True, check=True)
-        status_map: dict[str, str] = {}
-        for line in status_result.stdout.strip().split("\n"):
-            if not line:
-                continue
-            parts = line.split("\t")
-            if len(parts) >= 2:
-                # Status is first char of first field (e.g., "M", "A", "R100")
-                status_letter = parts[0][0]
-                filename = parts[-1]  # Last field is the path (handles renames)
-                status_map[filename] = status_letter
-
-        # Merge status into file dicts
+        # Merge status (and previous_path for renames) into file dicts.
         for f in files:
-            f["status"] = status_map.get(f["path"], "M")  # Default to M if unknown
+            path = f["path"]
+            f["status"] = status_map.get(path, "M")  # Default to M if unknown
+            if path in rename_map:
+                f["previous_path"] = rename_map[path]
 
         return files
     except subprocess.CalledProcessError as e:
@@ -714,7 +750,13 @@ def _collect_bitemporal_declarations(
         if os.path.basename(path) == _RULES_SCHEMA_BASENAME:
             continue
         if base_sha:
-            _ingest(_git_show_file(base_sha, path), "BASE")
+            # For renamed files, the BASE blob lives at the OLD path (previous_path).
+            # Using the new path for the BASE lookup silently misses the declaration
+            # when the file was renamed — breaking the escalation-only ratchet
+            # (issue #417). Fall back to path when previous_path is absent (new/
+            # modified files where old path == new path).
+            base_path = f.get("previous_path", path)
+            _ingest(_git_show_file(base_sha, base_path), "BASE")
         if head_sha:
             _ingest(_git_show_file(head_sha, path), "HEAD")
 

--- a/tests/unit/test_validate_review_bitemporal.py
+++ b/tests/unit/test_validate_review_bitemporal.py
@@ -1026,3 +1026,189 @@ class TestProvenanceMultiSourceAttribution:
         prov = data["provenance"]
         assert prov["CIV"] == ["PR_BODY"], prov["CIV"]
         assert prov["CRS"] == ["PR_BODY"], prov["CRS"]
+
+
+# ---------------------------------------------------------------------------
+# 13. Rename-aware BASE declaration read (issue #417)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestRenameAwareBaseDeclaration:
+    """_collect_bitemporal_declarations must use previous_path for BASE blob lookup
+    when a file has been renamed, so the escalation-only ratchet holds across
+    file renames (issue #417).
+
+    Two defects fixed together:
+    1. get_changed_files() must detect R-status renames and populate previous_path.
+    2. _collect_bitemporal_declarations() must use previous_path for BASE blob.
+    """
+
+    def test_rename_ratchet_keystone(self, monkeypatch) -> None:
+        """RENAME-RATCHET (KEYSTONE): renamed file whose BASE blob (OLD path)
+        declared REQUIRED_REVIEWERS, where the declaration is absent in HEAD
+        (new path) — the role MUST be retained.
+
+        Proves escalation-only set-union holds across a file rename.
+        Without the fix: _git_show_file(base_sha, new_path) returns None
+        (wrong path) -> BASE contribution silently missed -> ratchet bypassed.
+        With the fix: _git_show_file(base_sha, old_path) returns the BASE blob
+        -> role retained.
+        """
+        old_path = "governance/OLD-ADR.oct.md"
+        new_path = "governance/NEW-ADR.oct.md"
+
+        def fake_show(sha: str, path: str) -> str | None:
+            if sha == "base" and path == old_path:
+                # BASE blob at OLD path has a declaration
+                return "<!-- review-requirements: [CIV, SR] -->"
+            if sha == "head" and path == new_path:
+                # HEAD blob at NEW path has no declaration (removed)
+                return ""
+            # Any wrong-path call returns None — simulates blob-not-found
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+
+        # File dict with previous_path populated (as get_changed_files() will
+        # produce after the fix)
+        renamed_file = {
+            "path": new_path,
+            "previous_path": old_path,
+            "added": 2,
+            "deleted": 8,
+            "total_changed": 10,
+            "status": "renamed",
+        }
+
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=[renamed_file],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "CIV" in declared, (
+            "CIV declared in BASE blob at old path must be retained across rename "
+            "(escalation-only ratchet must hold)"
+        )
+        assert (
+            "SR" in declared
+        ), "SR declared in BASE blob at old path must be retained across rename"
+        assert "BASE" in prov.get("CIV", set()), "CIV must be attributed to BASE source"
+        assert "BASE" in prov.get("SR", set()), "SR must be attributed to BASE source"
+
+    def test_rename_no_previous_path_no_crash(self, monkeypatch) -> None:
+        """RENAME-NO-PREVIOUS: a new file (no previous_path key) is treated as
+        HEAD-only — no crash, no KeyError."""
+
+        def fake_show(sha: str, path: str) -> str | None:
+            if sha == "head":
+                return "<!-- review-requirements: [TMG] -->"
+            return None  # no base blob for new file
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+
+        # File dict WITHOUT previous_path (new file, added status)
+        new_file = {
+            "path": "governance/BRAND-NEW.oct.md",
+            "added": 30,
+            "deleted": 0,
+            "total_changed": 30,
+            "status": "A",
+        }
+
+        # Must not crash; must pick up HEAD declaration
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=[new_file],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "TMG" in declared, "HEAD declaration on new file must be collected"
+        assert prov.get("TMG") == {"HEAD"}, "TMG must be attributed to HEAD only"
+
+    def test_rename_same_path_regression_guard(self, monkeypatch) -> None:
+        """RENAME-SAME-PATH: a modified (non-renamed) file with no previous_path
+        still works correctly — regression guard for the fix."""
+
+        def fake_show(sha: str, path: str) -> str | None:
+            if sha == "base" and path == "src/hestai_mcp/core.py":
+                return "<!-- review-requirements: [CE] -->"
+            return ""
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+
+        modified_file = {
+            "path": "src/hestai_mcp/core.py",
+            "added": 10,
+            "deleted": 5,
+            "total_changed": 15,
+            "status": "M",
+        }
+
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=[modified_file],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "CE" in declared, "BASE declaration on modified file must still be collected"
+        assert "BASE" in prov.get("CE", set()), "CE must be attributed to BASE source"
+
+    def test_get_changed_files_rename_parsing(self, monkeypatch) -> None:
+        """get_changed_files() must detect R-status renames and produce dicts with
+        both path (new path) and previous_path (old path).
+
+        Also verifies the numstat path key is the new path only — NOT the
+        literal 'old => new' string that --numstat emits for renames.
+        """
+        import subprocess as sp
+        from unittest.mock import MagicMock
+
+        # --numstat output for a rename: git emits "{old}\t{new}" on a single tab-
+        # separated line when there is no brace expansion, but the ACTUAL format
+        # git uses for renames in --numstat is:
+        #   <added>\t<deleted>\t{old_path => new_path}
+        # or (with -M similarity threshold):
+        #   <added>\t<deleted>\told/path\tnew/path
+        # The common real-world format uses curly-brace notation in the filename
+        # column. We test the tab-separated 3-field form with the rename syntax
+        # that appears when full paths differ:
+        #   3\t1\told/governance/OLD-NAME.oct.md => new/governance/NEW-NAME.oct.md
+        numstat_output = "3\t1\told/governance/OLD-NAME.oct.md\tnew/governance/NEW-NAME.oct.md\n"
+        # --name-status output for the same rename: R<similarity>\t<old>\t<new>
+        name_status_output = (
+            "R100\told/governance/OLD-NAME.oct.md\tnew/governance/NEW-NAME.oct.md\n"
+        )
+
+        call_count = 0
+
+        def mock_run(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "--numstat" in cmd:
+                return MagicMock(returncode=0, stdout=numstat_output)
+            if "--name-status" in cmd:
+                return MagicMock(returncode=0, stdout=name_status_output)
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setattr(sp, "run", mock_run)
+        monkeypatch.delenv("CI", raising=False)
+
+        files = validate_review.get_changed_files()
+
+        assert len(files) == 1, f"Expected 1 file, got {len(files)}: {files}"
+        f = files[0]
+
+        # New path (not the 'old => new' string)
+        assert (
+            f["path"] == "new/governance/NEW-NAME.oct.md"
+        ), f"path must be new path only, got: {f['path']!r}"
+        # previous_path populated for renames
+        assert (
+            f.get("previous_path") == "old/governance/OLD-NAME.oct.md"
+        ), f"previous_path must be old path, got: {f.get('previous_path')!r}"
+        # status is 'renamed' (or 'R')
+        assert f.get("status") in (
+            "renamed",
+            "R",
+        ), f"status must indicate rename, got: {f.get('status')!r}"

--- a/tests/unit/test_validate_review_bitemporal.py
+++ b/tests/unit/test_validate_review_bitemporal.py
@@ -1154,37 +1154,12 @@ class TestRenameAwareBaseDeclaration:
         assert "CE" in declared, "BASE declaration on modified file must still be collected"
         assert "BASE" in prov.get("CE", set()), "CE must be attributed to BASE source"
 
-    def test_get_changed_files_rename_parsing(self, monkeypatch) -> None:
-        """get_changed_files() must detect R-status renames and produce dicts with
-        both path (new path) and previous_path (old path).
-
-        Also verifies the numstat path key is the new path only — NOT the
-        literal 'old => new' string that --numstat emits for renames.
-        """
+    def _make_rename_mock(self, monkeypatch, numstat_output: str, name_status_output: str):
+        """Helper: wire subprocess.run mocks for get_changed_files() rename tests."""
         import subprocess as sp
         from unittest.mock import MagicMock
 
-        # --numstat output for a rename: git emits "{old}\t{new}" on a single tab-
-        # separated line when there is no brace expansion, but the ACTUAL format
-        # git uses for renames in --numstat is:
-        #   <added>\t<deleted>\t{old_path => new_path}
-        # or (with -M similarity threshold):
-        #   <added>\t<deleted>\told/path\tnew/path
-        # The common real-world format uses curly-brace notation in the filename
-        # column. We test the tab-separated 3-field form with the rename syntax
-        # that appears when full paths differ:
-        #   3\t1\told/governance/OLD-NAME.oct.md => new/governance/NEW-NAME.oct.md
-        numstat_output = "3\t1\told/governance/OLD-NAME.oct.md\tnew/governance/NEW-NAME.oct.md\n"
-        # --name-status output for the same rename: R<similarity>\t<old>\t<new>
-        name_status_output = (
-            "R100\told/governance/OLD-NAME.oct.md\tnew/governance/NEW-NAME.oct.md\n"
-        )
-
-        call_count = 0
-
         def mock_run(cmd, **kwargs):
-            nonlocal call_count
-            call_count += 1
             if "--numstat" in cmd:
                 return MagicMock(returncode=0, stdout=numstat_output)
             if "--name-status" in cmd:
@@ -1194,20 +1169,78 @@ class TestRenameAwareBaseDeclaration:
         monkeypatch.setattr(sp, "run", mock_run)
         monkeypatch.delenv("CI", raising=False)
 
+    def test_get_changed_files_rename_parsing_plain_arrow(self, monkeypatch) -> None:
+        """Plain arrow: real git --numstat 3-field format for cross-directory rename.
+
+        Real git output:  3\\t1\\told/governance/OLD-NAME.oct.md => new/governance/NEW-NAME.oct.md
+        (single tab-separated 3-field line; ' => ' is inside the filename field)
+        """
+        numstat_output = "3\t1\told/governance/OLD-NAME.oct.md => new/governance/NEW-NAME.oct.md\n"
+        name_status_output = (
+            "R100\told/governance/OLD-NAME.oct.md\tnew/governance/NEW-NAME.oct.md\n"
+        )
+        self._make_rename_mock(monkeypatch, numstat_output, name_status_output)
+
         files = validate_review.get_changed_files()
 
         assert len(files) == 1, f"Expected 1 file, got {len(files)}: {files}"
         f = files[0]
-
-        # New path (not the 'old => new' string)
         assert (
             f["path"] == "new/governance/NEW-NAME.oct.md"
         ), f"path must be new path only, got: {f['path']!r}"
-        # previous_path populated for renames
         assert (
             f.get("previous_path") == "old/governance/OLD-NAME.oct.md"
         ), f"previous_path must be old path, got: {f.get('previous_path')!r}"
-        # status is 'renamed' (or 'R')
+        assert f.get("status") in (
+            "renamed",
+            "R",
+        ), f"status must indicate rename, got: {f.get('status')!r}"
+
+    def test_get_changed_files_rename_parsing_same_dir_brace(self, monkeypatch) -> None:
+        """Same-directory brace notation: git abbreviates same-dir renames with braces.
+
+        Real git output:  3\\t1\\tgovernance/rules/{OLD-NAME.oct.md => NEW-NAME.oct.md}
+        """
+        numstat_output = "3\t1\tgovernance/rules/{OLD-NAME.oct.md => NEW-NAME.oct.md}\n"
+        name_status_output = (
+            "R100\tgovernance/rules/OLD-NAME.oct.md\tgovernance/rules/NEW-NAME.oct.md\n"
+        )
+        self._make_rename_mock(monkeypatch, numstat_output, name_status_output)
+
+        files = validate_review.get_changed_files()
+
+        assert len(files) == 1, f"Expected 1 file, got {len(files)}: {files}"
+        f = files[0]
+        assert (
+            f["path"] == "governance/rules/NEW-NAME.oct.md"
+        ), f"path must be new path only, got: {f['path']!r}"
+        assert (
+            f.get("previous_path") == "governance/rules/OLD-NAME.oct.md"
+        ), f"previous_path must be old path, got: {f.get('previous_path')!r}"
+        assert f.get("status") in (
+            "renamed",
+            "R",
+        ), f"status must indicate rename, got: {f.get('status')!r}"
+
+    def test_get_changed_files_rename_parsing_cross_dir_brace(self, monkeypatch) -> None:
+        """Cross-directory brace notation: git abbreviates dir-level renames with braces.
+
+        Real git output:  3\\t1\\t{old/governance => new/governance}/rule.oct.md
+        """
+        numstat_output = "3\t1\t{old/governance => new/governance}/rule.oct.md\n"
+        name_status_output = "R100\told/governance/rule.oct.md\tnew/governance/rule.oct.md\n"
+        self._make_rename_mock(monkeypatch, numstat_output, name_status_output)
+
+        files = validate_review.get_changed_files()
+
+        assert len(files) == 1, f"Expected 1 file, got {len(files)}: {files}"
+        f = files[0]
+        assert (
+            f["path"] == "new/governance/rule.oct.md"
+        ), f"path must be new path only, got: {f['path']!r}"
+        assert (
+            f.get("previous_path") == "old/governance/rule.oct.md"
+        ), f"previous_path must be old path, got: {f.get('previous_path')!r}"
         assert f.get("status") in (
             "renamed",
             "R",


### PR DESCRIPTION
Closes #417

Fixes two related defects in `get_changed_files()` and `_collect_bitemporal_declarations()` where renamed files could bypass the escalation-only ratchet.

## Changes

- `get_changed_files()`: detect R-status renames in `--name-status` output, populate `previous_path` (old path) in renamed file dicts, handle the 4-field `--numstat` rename format so the path key is the new path only (not `"old => new"`)
- `_collect_bitemporal_declarations()`: use `f.get("previous_path", f["path"])` for BASE blob lookup on renamed files so the BASE-side declaration is read from the correct (old) path

## Root cause

A PR that renames a governance file AND removes its `REQUIRED_REVIEWERS` declaration in the same commit could silently downgrade the gate. The BASE blob for the renamed file exists at the _old_ path, but the prior code called `_git_show_file(base_sha, new_path)` — blob not found, BASE contribution silently missed, ratchet bypassed.

## Tests (RED-first)

- **RENAME-RATCHET** (keystone): renamed file whose BASE blob declared a role, removed in HEAD → role RETAINED
- **RENAME-NO-PREVIOUS**: new file (no `previous_path`) → no crash, HEAD declaration collected
- **RENAME-SAME-PATH**: modified (non-renamed) file → regression guard, BASE declaration collected
- **get_changed_files rename parsing**: R-status → correct `path`/`previous_path` dict, numstat path key is new path only

All 1154 tests pass. Coverage 92% (threshold: 89%).

<!-- review-requirements: [CIV, CE, CRS, SR, TMG] -->

Refs: PR #414, issue #412 cubic P1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rename handling in the review gate so BASE declarations read from the old path, preventing silent downgrades on renames. Also corrects `--numstat` rename parsing (arrow/brace 3‑field and 4‑field) and simplifies the provenance table to show source codes only.

- **Bug Fixes**
  - `get_changed_files`: parse R-status from `--name-status`, build rename map, set `previous_path`; resolve 3-field arrow/brace rename notation and handle 4-field lines; ensure `path` is the new path.
  - `_collect_bitemporal_declarations`: use `previous_path` for BASE blob lookup, falling back to the current path when absent.

- **Refactors**
  - Workflow `renderProvenance`: remove verbose labels; output `DIFF`, `HEAD`, `BASE`, `PR_BODY` codes with a short legend.

<sup>Written for commit c9a37d1eb4dcf57b2c3f3c9d26feeaffe675d4b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/HestAI-MCP/pull/421?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

